### PR TITLE
Chore/cfn template cleanup

### DIFF
--- a/app.yml
+++ b/app.yml
@@ -342,6 +342,7 @@ Resources:
     Type: AWS::CloudFront::Distribution
     Properties:
       DistributionConfig:
+        HttpVersion: http2
         Aliases:
           - !Ref website
         Origins:
@@ -427,4 +428,5 @@ Resources:
         PriceClass: PriceClass_All
         ViewerCertificate:
           AcmCertificateArn: !If [ createSSLCert, !Ref SSLCert, !Ref sslCertificateArn ]
-          SslSupportMethod: sni-only
+          SslSupportMethod: 'sni-only'
+          MinimumProtocolVersion: 'TLSv1.1_2016'

--- a/app.yml
+++ b/app.yml
@@ -249,7 +249,6 @@ Resources:
             Function: !GetAtt ResizeFunction.Arn
   SourceBucketPolicy:
     Type: AWS::S3::BucketPolicy
-    DependsOn: SourceBucket
     Properties:
       Bucket: !Ref SourceBucket
       PolicyDocument:
@@ -288,7 +287,6 @@ Resources:
             Function: !GetAtt SiteBuilderFunction.Arn
   ResizedBucketPolicy:
     Type: AWS::S3::BucketPolicy
-    DependsOn: ResizedBucket
     Properties:
       Bucket: !Ref ResizedBucket
       PolicyDocument:
@@ -313,7 +311,6 @@ Resources:
       BucketName: !Ref webBucket
   WebBucketPolicy:
     Type: AWS::S3::BucketPolicy
-    DependsOn: WebBucket
     Properties:
       Bucket: !Ref WebBucket
       PolicyDocument:

--- a/app.yml
+++ b/app.yml
@@ -385,14 +385,14 @@ Resources:
             ViewerProtocolPolicy: https-only
             PathPattern: 'pics/resized/*'
             ForwardedValues:
-              QueryString: 'false'
+              QueryString: false
           - TargetOriginId: S3-SourceBucket
             TrustedSigners:
               - self
             ViewerProtocolPolicy: https-only
             PathPattern: 'pics/original/*'
             ForwardedValues:
-              QueryString: 'false'
+              QueryString: false
           - TargetOriginId: Custom-LoginAPI
             ViewerProtocolPolicy: https-only
             PathPattern: 'Prod/*'
@@ -405,13 +405,13 @@ Resources:
               - PUT
               - PATCH
             ForwardedValues:
-              QueryString: 'false'
+              QueryString: false
               Headers:
                 - Accept
                 - Authorization
                 - Content-Type
                 - Referer
-        Enabled: 'true'
+        Enabled: true
         DefaultRootObject: index.html
         CustomErrorResponses:
           - ErrorCode: 403
@@ -425,7 +425,7 @@ Resources:
           TrustedSigners:
             - self
           ForwardedValues:
-            QueryString: 'false'
+            QueryString: false
           ViewerProtocolPolicy: redirect-to-https
         PriceClass: PriceClass_All
         ViewerCertificate:


### PR DESCRIPTION
I have used cfn-lint to cleanup the cloudformation template a little bit and enabled http2 on the cloudfront distribution.
I also updated the TLS settings to use TLS1.1 as a minimum version.
I will be adding a Makefile shortly that brings linting to the template and allows for more automation of current manual steps 😃 