### PR TITLE
updated to nodejs10.x after AWS deprecated nodejs8.10

### DIFF
--- a/app.yml
+++ b/app.yml
@@ -62,7 +62,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       CodeUri: dist/lambda-login.zip
       Role: !GetAtt LambdaRole.Arn
       Environment:
@@ -113,7 +113,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       CodeUri: dist/lambda-resize.zip
       Role: !GetAtt ResizeLambdaRole.Arn
       Environment:
@@ -164,7 +164,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       CodeUri: dist/lambda-site-builder.zip
       Environment:
         Variables:

--- a/app.yml
+++ b/app.yml
@@ -136,7 +136,7 @@ Resources:
         Variables:
           RESIZED_BUCKET: !Ref resizedBucket
       Timeout: 30
-      MemorySize: 960
+      MemorySize: 1024
 
   #
   # Resize IAM role so the Lambda can log (CloudWatch) and read/write S3 objects
@@ -215,7 +215,7 @@ Resources:
           WEBSITE: !Ref website
           GOOGLEANALYTICS: !Ref googleanalytics
       Role: !GetAtt SiteBuilderLambdaRole.Arn
-      Timeout: 300
+      Timeout: 900
       MemorySize: 3008
 
   #
@@ -288,11 +288,6 @@ Resources:
     DependsOn: ResizeInvokePermission
     Properties:
       BucketName: !Ref sourceBucket
-      PublicAccessBlockConfiguration:
-        BlockPublicAcls       : true
-        BlockPublicPolicy     : true
-        IgnorePublicAcls      : true
-        RestrictPublicBuckets : true
       NotificationConfiguration:
         LambdaConfigurations:
           - Event: 's3:ObjectCreated:*'
@@ -337,47 +332,20 @@ Resources:
               StringNotEquals:
                 "s3:x-amz-server-side-encryption":
                   - "AES256"
-                  #- "aws:kms"
     DependsOn: SourceBucket
 
 
   #
   # Resized Bucket
   #
-  
-
-
-  # THIS WAS THE OLD EXPEN$IVE WAY OF TRIGGERING THE SITEBUILDER
-  # SiteBuilderInvokePermission:
-  #   Type: AWS::Lambda::Permission
-  #   Properties:
-  #     Action: lambda:InvokeFunction
-  #     FunctionName: !Ref SiteBuilderFunction
-  #     Principal: s3.amazonaws.com
-  #     SourceAccount: !Ref AWS::AccountId
-  #     SourceArn: !Sub
-  #       - arn:aws:s3:::${resizedBucket}
-  #       - resizedBucket: !Ref resizedBucket
-
   ResizedBucket:
     Type: AWS::S3::Bucket
     Properties:
       BucketName: !Ref resizedBucket
-      PublicAccessBlockConfiguration:
-        BlockPublicAcls       : true
-        BlockPublicPolicy     : true
-        IgnorePublicAcls      : true
-        RestrictPublicBuckets : true
       BucketEncryption: 
         ServerSideEncryptionConfiguration: 
         - ServerSideEncryptionByDefault:
             SSEAlgorithm: AES256
-
-      # THIS WAS THE OLD EXPEN$IVE WAY OF TRIGGERING THE SITEBUILDER  
-      # NotificationConfiguration:
-      #   LambdaConfigurations:
-      #     - Event: 's3:ObjectCreated:*'
-      #       Function: !GetAtt SiteBuilderFunction.Arn
 
   ResizedBucketPolicy:
     Type: AWS::S3::BucketPolicy
@@ -414,7 +382,6 @@ Resources:
               StringNotEquals:
                 "s3:x-amz-server-side-encryption":
                   - "AES256"
-                  #- "aws:kms"
     DependsOn: ResizedBucket
 
   #

--- a/app.yml
+++ b/app.yml
@@ -49,7 +49,18 @@ Parameters:
     Description: Google tracking id (gtag)
     Type: String
   ImageMagickLayer:
-    Description: Lambda layer for nodejs10.x for imagemagick. Deploy one from here https://serverlessrepo.aws.amazon.com/applications/arn:aws:serverlessrepo:us-east-1:145266761615:applications~image-magick-lambda-layer 
+    Description: layer for nodejs10.x and nodejs12.x for imagemagick here https://serverlessrepo.aws.amazon.com/applications/arn:aws:serverlessrepo:us-east-1:145266761615:applications~image-magick-lambda-layer 
+    Type: String
+  LambdaRate:
+    Description: The rate (frequency) that determines when CloudWatch Events runs the rule that triggers the SiteBuilderFunction.
+    Default: rate(365 days)
+    AllowedValues:
+      - rate(8 hours)
+      - rate(1 day)
+      - rate(7 days)
+      - rate(30 days)
+      - rate(90 days)
+      - rate(365 days)
     Type: String
 
 Conditions:
@@ -125,7 +136,7 @@ Resources:
         Variables:
           RESIZED_BUCKET: !Ref resizedBucket
       Timeout: 30
-      MemorySize: 1024
+      MemorySize: 960
 
   #
   # Resize IAM role so the Lambda can log (CloudWatch) and read/write S3 objects
@@ -163,6 +174,29 @@ Resources:
                 Action: ['s3:PutObject']
 
   #
+  # CloudWatch Events Rule to run sitebuilder at some frequency
+  #
+  LambdaSchedule:
+    Type: "AWS::Events::Rule"
+    Properties:
+      Description: A schedule for the Lambda function..
+      ScheduleExpression: !Ref LambdaRate
+      State: ENABLED
+      Targets:
+        - Arn: !Sub ${SiteBuilderFunction.Arn}
+          Id: LambdaSchedule
+  #        
+  # Permission to invoke a lambda function with the CloudWatch Event
+  #
+  LambdaSchedulePermission:
+    Type: "AWS::Lambda::Permission"
+    Properties:
+      Action: 'lambda:InvokeFunction'
+      FunctionName: !Ref SiteBuilderFunction
+      Principal: 'events.amazonaws.com'
+      SourceArn: !Sub ${LambdaSchedule.Arn}
+
+  #
   # Site Builder Lambda function definition
   #
   SiteBuilderFunction:
@@ -181,8 +215,8 @@ Resources:
           WEBSITE: !Ref website
           GOOGLEANALYTICS: !Ref googleanalytics
       Role: !GetAtt SiteBuilderLambdaRole.Arn
-      Timeout: 30
-      MemorySize: 1024
+      Timeout: 300
+      MemorySize: 3008
 
   #
   # Site Builder IAM role so the Lambda can log (CloudWatch) and read/write S3 objects
@@ -248,15 +282,26 @@ Resources:
       SourceArn: !Sub
         - arn:aws:s3:::${sourceBucket}
         - sourceBucket: !Ref sourceBucket
+
   SourceBucket:
     Type: AWS::S3::Bucket
     DependsOn: ResizeInvokePermission
     Properties:
       BucketName: !Ref sourceBucket
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls       : true
+        BlockPublicPolicy     : true
+        IgnorePublicAcls      : true
+        RestrictPublicBuckets : true
       NotificationConfiguration:
         LambdaConfigurations:
           - Event: 's3:ObjectCreated:*'
             Function: !GetAtt ResizeFunction.Arn
+      BucketEncryption: 
+        ServerSideEncryptionConfiguration: 
+        - ServerSideEncryptionByDefault:
+            SSEAlgorithm: AES256
+
   SourceBucketPolicy:
     Type: AWS::S3::BucketPolicy
     Properties:
@@ -274,27 +319,66 @@ Resources:
                 - arn:aws:iam::cloudfront:user/CloudFront Origin Access Identity ${id}
                 - id: !Ref originAccessIdentity
 
+  ForceEncryption:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref sourceBucket
+      PolicyDocument:
+        Version: "2008-10-17"
+        Statement:
+          - Sid: DenyUnEncryptedObjectUploads
+            Effect: Deny
+            Principal: "*"
+            Action:
+              - s3:PutObject
+            Resource:
+              - !Join ["", ["arn:aws:s3:::", !Ref sourceBucket, "/*"]]
+            Condition:
+              StringNotEquals:
+                "s3:x-amz-server-side-encryption":
+                  - "AES256"
+                  #- "aws:kms"
+    DependsOn: SourceBucket
+
+
   #
   # Resized Bucket
   #
-  SiteBuilderInvokePermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      Action: lambda:InvokeFunction
-      FunctionName: !Ref SiteBuilderFunction
-      Principal: s3.amazonaws.com
-      SourceAccount: !Ref AWS::AccountId
-      SourceArn: !Sub
-        - arn:aws:s3:::${resizedBucket}
-        - resizedBucket: !Ref resizedBucket
+  
+
+
+  # THIS WAS THE OLD EXPEN$IVE WAY OF TRIGGERING THE SITEBUILDER
+  # SiteBuilderInvokePermission:
+  #   Type: AWS::Lambda::Permission
+  #   Properties:
+  #     Action: lambda:InvokeFunction
+  #     FunctionName: !Ref SiteBuilderFunction
+  #     Principal: s3.amazonaws.com
+  #     SourceAccount: !Ref AWS::AccountId
+  #     SourceArn: !Sub
+  #       - arn:aws:s3:::${resizedBucket}
+  #       - resizedBucket: !Ref resizedBucket
+
   ResizedBucket:
     Type: AWS::S3::Bucket
     Properties:
       BucketName: !Ref resizedBucket
-      NotificationConfiguration:
-        LambdaConfigurations:
-          - Event: 's3:ObjectCreated:*'
-            Function: !GetAtt SiteBuilderFunction.Arn
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls       : true
+        BlockPublicPolicy     : true
+        IgnorePublicAcls      : true
+        RestrictPublicBuckets : true
+      BucketEncryption: 
+        ServerSideEncryptionConfiguration: 
+        - ServerSideEncryptionByDefault:
+            SSEAlgorithm: AES256
+
+      # THIS WAS THE OLD EXPEN$IVE WAY OF TRIGGERING THE SITEBUILDER  
+      # NotificationConfiguration:
+      #   LambdaConfigurations:
+      #     - Event: 's3:ObjectCreated:*'
+      #       Function: !GetAtt SiteBuilderFunction.Arn
+
   ResizedBucketPolicy:
     Type: AWS::S3::BucketPolicy
     Properties:
@@ -311,6 +395,27 @@ Resources:
               AWS: !Sub
                 - arn:aws:iam::cloudfront:user/CloudFront Origin Access Identity ${id}
                 - id: !Ref originAccessIdentity
+
+  ForceEncryption:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref resizedBucket
+      PolicyDocument:
+        Version: "2008-10-17"
+        Statement:
+          - Sid: DenyUnEncryptedObjectUploads
+            Effect: Deny
+            Principal: "*"
+            Action:
+              - s3:PutObject
+            Resource:
+              - !Join ["", ["arn:aws:s3:::", !Ref resizedBucket, "/*"]]
+            Condition:
+              StringNotEquals:
+                "s3:x-amz-server-side-encryption":
+                  - "AES256"
+                  #- "aws:kms"
+    DependsOn: ResizedBucket
 
   #
   # Web Bucket
@@ -392,6 +497,10 @@ Resources:
               - self
             ViewerProtocolPolicy: https-only
             PathPattern: 'pics/resized/*'
+            Compress: true
+            MinTTL: 0
+            DefaultTTL: 31536000
+            MaxTTL: 31536000
             ForwardedValues:
               QueryString: false
           - TargetOriginId: S3-SourceBucket
@@ -399,6 +508,10 @@ Resources:
               - self
             ViewerProtocolPolicy: https-only
             PathPattern: 'pics/original/*'
+            Compress: true
+            MinTTL: 0
+            DefaultTTL: 31536000
+            MaxTTL: 31536000
             ForwardedValues:
               QueryString: false
           - TargetOriginId: Custom-LoginAPI
@@ -435,7 +548,7 @@ Resources:
           ForwardedValues:
             QueryString: false
           ViewerProtocolPolicy: redirect-to-https
-        PriceClass: PriceClass_All
+        PriceClass: PriceClass_100
         ViewerCertificate:
           AcmCertificateArn: !If [ createSSLCert, !Ref SSLCert, !Ref sslCertificateArn ]
           SslSupportMethod: 'sni-only'

--- a/app.yml
+++ b/app.yml
@@ -48,6 +48,9 @@ Parameters:
   googleanalytics:
     Description: Google tracking id (gtag)
     Type: String
+  ImageMagickLayer:
+    Description: Lambda layer for nodejs10.x for imagemagick. Deploy one from here https://serverlessrepo.aws.amazon.com/applications/arn:aws:serverlessrepo:us-east-1:145266761615:applications~image-magick-lambda-layer 
+    Type: String
 
 Conditions:
   createSSLCert: !Equals [ !Ref sslCertificateArn, "" ]
@@ -115,6 +118,8 @@ Resources:
       Handler: index.handler
       Runtime: nodejs10.x
       CodeUri: dist/lambda-resize.zip
+      Layers:
+        - !Ref ImageMagickLayer
       Role: !GetAtt ResizeLambdaRole.Arn
       Environment:
         Variables:

--- a/config.example.json
+++ b/config.example.json
@@ -7,6 +7,7 @@
   "originAccessIdentity=EJG...",
   "sessionDuration=86400",
   "googleanalytics=",
+  "ImageMagickLayer=arn:aws:lambda:us-east-1:........:layer:image-magick:...",
   "kmsKeyId=00000000-0000-0000-0000-000000000000",
   "cloudFrontKeypairId=APK...",
   "encryptedCloudFrontPrivateKey=AQICAH...",

--- a/login/Dockerfile
+++ b/login/Dockerfile
@@ -1,4 +1,4 @@
-FROM lambci/lambda:build-nodejs8.10
+FROM lambci/lambda:build-nodejs10.x
 
 # working folder
 RUN mkdir /build

--- a/resize/Dockerfile
+++ b/resize/Dockerfile
@@ -1,4 +1,4 @@
-FROM lambci/lambda:build-nodejs8.10
+FROM lambci/lambda:build-nodejs10.x
 
 # working folder
 RUN mkdir /build

--- a/site-builder/Dockerfile
+++ b/site-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM lambci/lambda:build-nodejs8.10
+FROM lambci/lambda:build-nodejs10.x
 
 # working folder
 RUN mkdir /build

--- a/site-builder/index.js
+++ b/site-builder/index.js
@@ -124,7 +124,7 @@ function uploadHomepageSite(albums, pictures, metadata) {
         Bucket: process.env.SITE_BUCKET,
         Key: path.relative(dir, f),
         Body: body,
-        ContentType: mime.lookup(path.extname(f))
+        ContentType: mime.getType(path.extname(f))
       };
 
       s3.putObject(options, cb);
@@ -184,7 +184,7 @@ function uploadAlbumSite(title, pictures, metadata) {
         Bucket: process.env.SITE_BUCKET,
         Key: title + "/" + path.relative(dir, f),
         Body: body,
-        ContentType: mime.lookup(path.extname(f))
+        ContentType: mime.getType(path.extname(f))
       };
 
       s3.putObject(options, cb);

--- a/site-builder/index.js
+++ b/site-builder/index.js
@@ -145,7 +145,7 @@ function uploadAlbumSite(title, pictures, metadata) {
       if (path.basename(f) == 'index.html') {
         // Defaults
         var renderedTitle = title,
-            comment1 = '';
+            comment1 = '',
             comment2 = '';
 
         // Metadata

--- a/site-builder/package.json
+++ b/site-builder/package.json
@@ -7,7 +7,7 @@
   "main": "index.js",
   "dependencies": {
     "async": "^2.1.4",
-    "mime": "^1.3.6",
+    "mime": "^2.0.5",
     "js-yaml": "^3.8.4"
   }
 }


### PR DESCRIPTION
and updated site-builder to mime2.0.5 so it deploys. the lookup() method in mime had been deprecated in favor of getType() in mime versions > 2