### PR TITLE
corrected error in ServerSideAES256 and Forced Encryption config, 

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ the Resize Function and the SiteBuilder Function in Lambda in the Management con
 CloudWatch Events rule that runs SiteBuilder or 3) manually disabling the trigger for a Lambda function 
 in the Management console.
 
-Default directory for photos is S3://BUCKET_NAME/pics/original/YOUR_ALBUMS_GO_HERE.
+Default directory for photos is S3://BUCKET_NAME/pics/original/YOUR_ALBUMS_GO_HERE
 
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -269,6 +269,8 @@ the Resize Function and the SiteBuilder Function in Lambda in the Management con
 CloudWatch Events rule that runs SiteBuilder or 3) manually disabling the trigger for a Lambda function 
 in the Management console.
 
+Default directory for photos is S3://BUCKET_NAME/pics/original/YOUR_ALBUMS_GO_HERE.
+
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ There are 7 main components:
 6. **Resize lambda function** to automatically resize images added to the source
    S3 bucket and store them in the resized S3 bucket.
 7. **Site builder lambda function** to automatically rebuild the static website
-   when changes are made to the source S3 bucket.
+   when ~~changes are made to the source S3 bucket~~ a regularly scheduled event
+   fires from Cloudwatch Events.
 
 ## Pre-requisites
 
@@ -179,6 +180,9 @@ modified resources.
 The first deployment should take about 30 minutes since there's a lot to set up.
 You'll also receive an email to approve the SSL certificate request, which you
 should complete quickly, so that the rest of the deployment can proceed.
+
+You will want to update the frequency of the Cloudwatch Events Rule from its default setting at 365 days to something more appropriate to your needs. You can adjust this pre-deployment
+in the app.yml file or after the fact in the AWS Management console.
 
 ### Note on ImageMagick Layer for Lambda
 When Amazon deprecated Node.js 8.10, they removed ImageMagick from the Amazon Linux 2 AMIs that are required to run Node.js 10.x. Again, ImageMagick is no longer bundled with the Node.js 10.x runtime. This fix may also help with running on Node.js 12.x in the future. This provides a Lambda Layer (essentially a library) for your Lambda function that makes the existing code work with Node.js 10.x. 

--- a/app.yml
+++ b/app.yml
@@ -136,7 +136,7 @@ Resources:
         Variables:
           RESIZED_BUCKET: !Ref resizedBucket
       Timeout: 30
-      MemorySize: 960
+      MemorySize: 1024
 
   #
   # Resize IAM role so the Lambda can log (CloudWatch) and read/write S3 objects
@@ -195,6 +195,15 @@ Resources:
       FunctionName: !Ref SiteBuilderFunction
       Principal: 'events.amazonaws.com'
       SourceArn: !Sub ${LambdaSchedule.Arn}
+
+  EventInvokeConfig:
+    Type: AWS::Lambda::EventInvokeConfig
+    Properties:
+        FunctionName: !Ref SiteBuilderFunction
+        Qualifier: "$LATEST"
+        MaximumEventAgeInSeconds: 60
+        MaximumRetryAttempts: 0
+    DependsOn: LambdaSchedulePermission
 
   #
   # Site Builder Lambda function definition
@@ -288,15 +297,15 @@ Resources:
     DependsOn: ResizeInvokePermission
     Properties:
       BucketName: !Ref sourceBucket
+      NotificationConfiguration:
+        LambdaConfigurations:
+          - Event: 's3:ObjectCreated:*'
+            Function: !GetAtt ResizeFunction.Arn
       PublicAccessBlockConfiguration:
         BlockPublicAcls       : true
         BlockPublicPolicy     : true
         IgnorePublicAcls      : true
         RestrictPublicBuckets : true
-      NotificationConfiguration:
-        LambdaConfigurations:
-          - Event: 's3:ObjectCreated:*'
-            Function: !GetAtt ResizeFunction.Arn
       BucketEncryption: 
         ServerSideEncryptionConfiguration: 
           - ServerSideEncryptionByDefault:
@@ -531,9 +540,9 @@ Resources:
           AcmCertificateArn: !If [ createSSLCert, !Ref SSLCert, !Ref sslCertificateArn ]
           SslSupportMethod: 'sni-only'
           MinimumProtocolVersion: 'TLSv1.1_2016'
-        Restrictions:
-          GeoRestriction:
-            RestrictionType: 'whitelist'
-            Locations: 
-              - 'US'
+        # Restrictions:
+        #   GeoRestriction:
+        #     RestrictionType: 'whitelist'
+        #     Locations: 
+        #       - 'US'
             

--- a/app.yml
+++ b/app.yml
@@ -136,7 +136,7 @@ Resources:
         Variables:
           RESIZED_BUCKET: !Ref resizedBucket
       Timeout: 30
-      MemorySize: 1024
+      MemorySize: 960
 
   #
   # Resize IAM role so the Lambda can log (CloudWatch) and read/write S3 objects
@@ -288,14 +288,28 @@ Resources:
     DependsOn: ResizeInvokePermission
     Properties:
       BucketName: !Ref sourceBucket
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls       : true
+        BlockPublicPolicy     : true
+        IgnorePublicAcls      : true
+        RestrictPublicBuckets : true
       NotificationConfiguration:
         LambdaConfigurations:
           - Event: 's3:ObjectCreated:*'
             Function: !GetAtt ResizeFunction.Arn
       BucketEncryption: 
         ServerSideEncryptionConfiguration: 
-        - ServerSideEncryptionByDefault:
-            SSEAlgorithm: AES256
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      LifecycleConfiguration:
+        Rules:
+          - Id: CheaperS3StorageIntelligentTieringBecauseCachedOnCloudfront
+            Status: Enabled
+            AbortIncompleteMultipartUpload:
+              DaysAfterInitiation: 7
+            Transition:
+              StorageClass: INTELLIGENT_TIERING
+              TransitionInDays: 30
 
   SourceBucketPolicy:
     Type: AWS::S3::BucketPolicy
@@ -313,14 +327,6 @@ Resources:
               AWS: !Sub
                 - arn:aws:iam::cloudfront:user/CloudFront Origin Access Identity ${id}
                 - id: !Ref originAccessIdentity
-
-  ForceEncryption:
-    Type: AWS::S3::BucketPolicy
-    Properties:
-      Bucket: !Ref sourceBucket
-      PolicyDocument:
-        Version: "2008-10-17"
-        Statement:
           - Sid: DenyUnEncryptedObjectUploads
             Effect: Deny
             Principal: "*"
@@ -334,7 +340,6 @@ Resources:
                   - "AES256"
     DependsOn: SourceBucket
 
-
   #
   # Resized Bucket
   #
@@ -342,10 +347,24 @@ Resources:
     Type: AWS::S3::Bucket
     Properties:
       BucketName: !Ref resizedBucket
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls       : true
+        BlockPublicPolicy     : true
+        IgnorePublicAcls      : true
+        RestrictPublicBuckets : true
       BucketEncryption: 
         ServerSideEncryptionConfiguration: 
-        - ServerSideEncryptionByDefault:
-            SSEAlgorithm: AES256
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      LifecycleConfiguration:
+        Rules:
+          - Id: CheaperS3StorageIntelligentTieringBecauseCachedOnCloudfront
+            Status: Enabled
+            AbortIncompleteMultipartUpload:
+              DaysAfterInitiation: 7
+            Transition:
+              StorageClass: INTELLIGENT_TIERING
+              TransitionInDays: 30
 
   ResizedBucketPolicy:
     Type: AWS::S3::BucketPolicy
@@ -363,14 +382,6 @@ Resources:
               AWS: !Sub
                 - arn:aws:iam::cloudfront:user/CloudFront Origin Access Identity ${id}
                 - id: !Ref originAccessIdentity
-
-  ForceEncryption:
-    Type: AWS::S3::BucketPolicy
-    Properties:
-      Bucket: !Ref resizedBucket
-      PolicyDocument:
-        Version: "2008-10-17"
-        Statement:
           - Sid: DenyUnEncryptedObjectUploads
             Effect: Deny
             Principal: "*"
@@ -466,7 +477,7 @@ Resources:
             PathPattern: 'pics/resized/*'
             Compress: true
             MinTTL: 0
-            DefaultTTL: 31536000
+            DefaultTTL: 86400
             MaxTTL: 31536000
             ForwardedValues:
               QueryString: false
@@ -477,7 +488,7 @@ Resources:
             PathPattern: 'pics/original/*'
             Compress: true
             MinTTL: 0
-            DefaultTTL: 31536000
+            DefaultTTL: 86400
             MaxTTL: 31536000
             ForwardedValues:
               QueryString: false
@@ -520,3 +531,9 @@ Resources:
           AcmCertificateArn: !If [ createSSLCert, !Ref SSLCert, !Ref sslCertificateArn ]
           SslSupportMethod: 'sni-only'
           MinimumProtocolVersion: 'TLSv1.1_2016'
+        Restrictions:
+          GeoRestriction:
+            RestrictionType: 'whitelist'
+            Locations: 
+              - 'US'
+            

--- a/resize/index.js
+++ b/resize/index.js
@@ -66,6 +66,7 @@ exports.handler = function(event, context) {
               "Bucket": process.env.RESIZED_BUCKET,
               "Key": "pics/resized/" + config + "/" + image.originalKey.replace("pics/original/", ""),
               "Body": buffer,
+              "ServerSideEncryption": "AES256",
               "ContentType": image.contentType
             }, function(err) {
               cb(err);


### PR DESCRIPTION
- corrected (serious) error in ServerSideAES256 and Forced Encryption config
- Added Privacy filter back for the s3 buckets (the error was related to the Forced Encryption mistake above)
- added georestriction in cloudfront
- added basic lifecycle rules for the photos in storage to optimize storage costs after 30 days
- modified resize function to put objects using AES256 encryption.
- The photo data is properly protected at rest now!