### PR TITLE
Unit tests for lambda node.js code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12'
+      - run: npm install
+      - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ dist/
 .sass-cache/
 *.css.map
 .idea/
+package-lock.json
+.nyc_output/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - lts/*
+install:
+  - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: node_js
-node_js:
-  - lts/*
-install:
-  - npm install

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "AWSPics",
+  "dependencies": {
+    "async": "^2.1.4",
+    "js-yaml": "^3.8.4",
+    "mime": "^2.0.5"
+  },
+  "devDependencies": {
+    "chai": "^4.2.0",
+    "mocha": "^8.2.1",
+    "mock-require": "^3.0.3",
+    "nyc": "^15.1.0",
+    "rewire": "^4.0.1",
+    "sinon": "^9.2.0",
+    "sinon-chai": "^3.5.0"
+  },
+  "scripts": {
+    "test": "nyc mocha --recursive"
+  }
+}

--- a/site-builder/index.js
+++ b/site-builder/index.js
@@ -1,30 +1,45 @@
-var AWS = require("aws-sdk");
-var s3 = new AWS.S3({signatureVersion: 'v4'});
-var cloudfront = new AWS.CloudFront();
+const AWS = require("aws-sdk");
+const s3 = new AWS.S3({signatureVersion: 'v4'});
+const cloudfront = new AWS.CloudFront();
 
-var async = require('async');
-var fs = require('fs');
-var mime = require('mime');
-var path = require('path');
-var yaml = require('js-yaml');
+const async = require('async');
+const fs = require('fs');
+const mime = require('mime');
+const path = require('path');
+const yaml = require('js-yaml');
 
-var walk = function(dir, done) {
-  var results = [];
+function walk(dir, done) {
+  let results = [];
+
   fs.readdir(dir, function(err, list) {
-    if (err) return done(err);
-    var pending = list.length;
-    if (!pending) return done(null, results);
+    /* istanbul ignore next */
+    if (err) {
+      return done(err);
+    }
+
+    let pending = list.length;
+    if (!pending) {
+      return done(null, results);
+    }
+
     list.forEach(function(file) {
       file = path.resolve(dir, file);
       fs.stat(file, function(err, stat) {
         if (stat && stat.isDirectory()) {
           walk(file, function(err, res) {
             results = results.concat(res);
-            if (!--pending) done(null, results);
+
+            if (!--pending) {
+              done(null, results);
+            }
           });
-        } else {
+        }
+        else {
           results.push(file);
-          if (!--pending) done(null, results);
+
+          if (!--pending) {
+            done(null, results);
+          }
         }
       });
     });
@@ -41,16 +56,19 @@ function folderName(path) {
 
 // Test if object is empty or not
 function isEmpty(obj) {
-  for(var key in obj) {
-    if(obj.hasOwnProperty(key))
+  for (const key in obj) {
+    if (obj.hasOwnProperty(key)) {
       return false;
+    }
   }
+
   return true;
 }
 
 // Google Analytics gtag code
-var ga = "<!-- Global site tag (gtag.js) - Google Analytics -->\n" +
-  "\t\t<script async src=\"https://www.googletagmanager.com/gtag/js?id={gtag}\"></script>\n" +
+const ga = "<!-- Global site tag (gtag.js) - Google Analytics -->\n" +
+  "\t\t<script async src=\"https://www.googletagmanager.com/gtag/js?id={gtag}\">" +
+  "</script>\n" +
   "\t\t<script>\n" +
   "\t\t  window.dataLayer = window.dataLayer || [];\n" +
   "\t\t  function gtag(){dataLayer.push(arguments);}\n" +
@@ -59,18 +77,28 @@ var ga = "<!-- Global site tag (gtag.js) - Google Analytics -->\n" +
   "\t\t</script>";
 
 function getAlbums(data) {
-  var objects = data.sort(function(a,b){
-    return b.LastModified - a.LastModified;
-  }).map(stripPrefix);
-  var albums = objects.map(folderName);
-  // Deduplicate albums
-  albums = albums.filter(function(item, pos) {
-    return albums.indexOf(item) == pos;
-  });
+  const objects = data
+    .sort(function(a,b) {
+      return b.LastModified - a.LastModified;
+    })
+    .map(stripPrefix);
 
-  var pictures = albums.map(function(album){
-    return objects.filter(function(object){
-      return object.startsWith(album + "/") && (object.toLowerCase().endsWith('.jpg') || object.toLowerCase().endsWith('.png'));
+  const albums = objects
+    .map(folderName)
+    // Deduplicate albums
+    .filter(function(item, pos, self) {
+      return self.indexOf(item) == pos;
+    });
+
+  const pictures = albums.map(function(album) {
+    return objects.filter(function(object) {
+      return (
+        object.startsWith(album + "/") &&
+        (
+          object.toLowerCase().endsWith('.jpg') ||
+          object.toLowerCase().endsWith('.png')
+        )
+      );
     });
   });
 
@@ -78,49 +106,68 @@ function getAlbums(data) {
 }
 
 function uploadHomepageSite(albums, pictures, metadata) {
-  var dir = 'homepage';
+  const dir = 'homepage';
   walk(dir, function(err, files) {
-    if (err) throw err;
+    /* istanbul ignore next */
+    if (err) {
+      throw err;
+    }
 
     async.map(files, function(f, cb) {
-      var body = fs.readFileSync(f);
+      let body = fs.readFileSync(f);
 
       if (path.basename(f) == 'error.html') {
         // Test if "googleanalytics" is set or not
         if (!isEmpty(process.env.GOOGLEANALYTICS)) {
-          body = body.toString().replace(/\{website\}/g, process.env.WEBSITE)
-                                .replace(/\{googletracking\}/g, ga)
-                                .replace(/\{gtag\}/g, process.env.GOOGLEANALYTICS);
+          body = body
+            .toString()
+            .replace(/\{website\}/g, process.env.WEBSITE)
+            .replace(/\{googletracking\}/g, ga)
+            .replace(/\{gtag\}/g, process.env.GOOGLEANALYTICS);
         } else {
-          body = body.toString().replace(/\{website\}/g, process.env.WEBSITE)
-                                .replace('{googletracking}', '');
+          body = body
+            .toString()
+            .replace(/\{website\}/g, process.env.WEBSITE)
+            .replace('{googletracking}', '');
         }
       } else if (path.basename(f) == 'index.html') {
-        var picturesHTML = '';
-        for (var i = 0; i < albums.length; i++) {
-          var albumTitle = albums[i];
+        let picturesHTML = '';
+
+        for (let i = 0; i < albums.length; i++) {
+          let albumTitle = albums[i];
+
           if (metadata[i] && metadata[i].title) {
             albumTitle = metadata[i].title;
           }
-          picturesHTML += "\t\t\t\t\t\t<article class=\"thumb\">\n" +
-                          "\t\t\t\t\t\t\t<a href=\"" + albums[i] + "/index.html\" class=\"image\"><img src=\"/pics/resized/1200x750/" + pictures[i][0] + "\" alt=\"\" /></a>\n" +
-                          "\t\t\t\t\t\t\t<h2>" + albumTitle + "</h2>\n" +
-                          "\t\t\t\t\t\t</article>";
+
+          picturesHTML += (
+            "\t\t\t\t\t\t<article class=\"thumb\">\n" +
+            "\t\t\t\t\t\t\t<a href=\"" + albums[i] +
+            "/index.html\" class=\"image\"><img src=\"/pics/resized/1200x750/" +
+            pictures[i][0] + "\" alt=\"\" /></a>\n" +
+            "\t\t\t\t\t\t\t<h2>" + albumTitle + "</h2>\n" +
+            "\t\t\t\t\t\t</article>"
+          );
         }
+
         // Test if "googleanalytics" is set or not
         if (!isEmpty(process.env.GOOGLEANALYTICS)) {
-          body = body.toString().replace(/\{title\}/g, process.env.WEBSITE_TITLE)
-                                .replace(/\{pictures\}/g, picturesHTML)
-                                .replace(/\{googletracking\}/g, ga)
-                                .replace(/\{gtag\}/g, process.env.GOOGLEANALYTICS);
+          body = body
+            .toString()
+            .replace(/\{title\}/g, process.env.WEBSITE_TITLE)
+            .replace(/\{pictures\}/g, picturesHTML)
+            .replace(/\{googletracking\}/g, ga)
+            .replace(/\{gtag\}/g, process.env.GOOGLEANALYTICS);
         } else {
-          body = body.toString().replace(/\{title\}/g, process.env.WEBSITE_TITLE)
-                                .replace(/\{pictures\}/g, picturesHTML)
-                                .replace('{googletracking}', '');
+          body = body
+            .toString()
+            .replace(/\{title\}/g, process.env.WEBSITE_TITLE)
+            .replace(/\{pictures\}/g, picturesHTML)
+            .replace('{googletracking}', '');
         }
       }
 
-      var options = {
+      const options = {
         Bucket: process.env.SITE_BUCKET,
         Key: path.relative(dir, f),
         Body: body,
@@ -128,72 +175,108 @@ function uploadHomepageSite(albums, pictures, metadata) {
       };
 
       s3.putObject(options, cb);
-    }, function(err, results) {
-      if (err) console.log(err, err.stack);
+    },
+    /* istanbul ignore next */
+    function(err, results) {
+      if (err) {
+        console.log(err, err.stack);
+      }
     });
   });
 }
 
-function uploadAlbumSite(title, pictures, metadata) {
-  console.log("Writing ALBUM " + title);
-  //this is a computationally expensive way to do a delay block - 
-  //this delay is ~100ms using processor allocated to 3008mb memory usage on a Lambda instance
-  //Surely this could be done in a more node.js way, but if you're reading this, 
-  //Lambda computational power is likely cheaper than your time.
-  var a = 0;
-  for (var j = 5*10e6; j >= 0; j--) {
+/* istanbul ignore next */
+function delayBlock() {
+  // This is a computationally expensive way to do a delay block -
+  // this delay is ~100ms using processor allocated to 3008mb memory usage on a
+  // Lambda instance.
+  // Surely this could be done in a more node.js way, but if you're reading this,
+  // Lambda computational power is likely cheaper than your time.
+  let a = 0;
+  for (let j = 5*10e6; j >= 0; j--) {
     a++;
   }
-  //the above delay block is inserted to prevent S3 from being flooded and killing the sitebuild.
-  //This happens when you have more than 115 albums, writing about 30 files per album
-  //saturates the 3500 writes/sec current rate limit for S3, and this function 
-  //doesn't handle those rejections well & hangs without some delay block to force a rate limit.
-  //--------------------------
-  var dir = 'album';
+}
+
+function uploadAlbumSite(title, pictures, metadata) {
+  console.log("Writing ALBUM " + title);
+
+  // This delay block is inserted to prevent S3 from being flooded and killing
+  // the sitebuild.
+  // This happens when you have more than 115 albums, writing about 30 files per
+  // album saturates the 3500 writes/sec current rate limit for S3, and this
+  // function doesn't handle those rejections well & hangs without some delay
+  // block to force a rate limit.
+  delayBlock();
+
+  const dir = 'album';
   walk(dir, function(err, files) {
-    if (err) throw err;
+    /* istanbul ignore next */
+    if (err) {
+      throw err;
+    }
+
     async.map(files, function(f, cb) {
-      var body = fs.readFileSync(f);
+      let body = fs.readFileSync(f);
 
       if (path.basename(f) == 'index.html') {
         // Defaults
-        var renderedTitle = title,
+        let renderedTitle = title,
             comment1 = '',
             comment2 = '';
 
         // Metadata
         if (metadata) {
-          if (metadata.title) renderedTitle = metadata.title;
-          if (metadata.comment1) comment1 = metadata.comment1;
-          if (metadata.comment2) comment2 = metadata.comment2;
+          if (metadata.title) {
+            renderedTitle = metadata.title;
+          }
+          if (metadata.comment1) {
+            comment1 = metadata.comment1;
+          }
+          if (metadata.comment2) {
+            comment2 = metadata.comment2;
+          }
         }
 
         // Pictures
-        var picturesHTML = '';
-        for (var i = pictures.length - 1; i >= 0; i--) {
-          picturesHTML += "\t\t\t\t\t\t<article>\n" +
-                          "\t\t\t\t\t\t\t<a class=\"thumbnail\" href=\"/pics/resized/1200x750/" + pictures[i] + "\" data-position=\"center\"><img class=\"lazy\" src=\"assets/css/images/placeholder.png\" data-original=\"/pics/resized/360x225/" + pictures[i] + "\" width=\"360\" height=\"225\"/></a>\n" +
-                          "<p><a href=\"/pics/original/" + pictures[i] + "\" download>High Resolution Download</a></p>\n" +
-                          "\t\t\t\t\t\t</article>";
+        let picturesHTML = '';
+        for (let i = pictures.length - 1; i >= 0; i--) {
+          picturesHTML += (
+            "\t\t\t\t\t\t<article>\n" +
+            "\t\t\t\t\t\t\t<a class=\"thumbnail\" href=\"/pics/resized/1200x750/" +
+            pictures[i] +
+            "\" data-position=\"center\">" +
+            "<img class=\"lazy\" src=\"assets/css/images/placeholder.png\" " +
+            "data-original=\"/pics/resized/360x225/" + pictures[i] +
+            "\" width=\"360\" height=\"225\"/></a>\n" +
+            "<p><a href=\"/pics/original/" + pictures[i] +
+            "\" download>High Resolution Download</a></p>\n" +
+            "\t\t\t\t\t\t</article>"
+          );
         }
+
         // Test if "googleanalytics" is set or not
         if (!isEmpty(process.env.GOOGLEANALYTICS)) {
-          body = body.toString().replace(/\{title\}/g, renderedTitle)
-                                .replace(/\{comment1\}/g, comment1)
-                                .replace(/\{comment2\}/g, comment2)
-                                .replace(/\{pictures\}/g, picturesHTML)
-                                .replace(/\{googletracking\}/g, ga)
-                                .replace(/\{gtag\}/g, process.env.GOOGLEANALYTICS);
+          body = body
+            .toString()
+            .replace(/\{title\}/g, renderedTitle)
+            .replace(/\{comment1\}/g, comment1)
+            .replace(/\{comment2\}/g, comment2)
+            .replace(/\{pictures\}/g, picturesHTML)
+            .replace(/\{googletracking\}/g, ga)
+            .replace(/\{gtag\}/g, process.env.GOOGLEANALYTICS);
         } else {
-          body = body.toString().replace(/\{title\}/g, renderedTitle)
-                                .replace(/\{comment1\}/g, comment1)
-                                .replace(/\{comment2\}/g, comment2)
-                                .replace(/\{pictures\}/g, picturesHTML)
-                                .replace('{googletracking}', '');
+          body = body
+            .toString()
+            .replace(/\{title\}/g, renderedTitle)
+            .replace(/\{comment1\}/g, comment1)
+            .replace(/\{comment2\}/g, comment2)
+            .replace(/\{pictures\}/g, picturesHTML)
+            .replace('{googletracking}', '');
         }
       }
 
-      var options = {
+      const options = {
         Bucket: process.env.SITE_BUCKET,
         Key: title + "/" + path.relative(dir, f),
         Body: body,
@@ -201,22 +284,26 @@ function uploadAlbumSite(title, pictures, metadata) {
       };
 
       s3.putObject(options, cb);
-    }, function(err, results) {
-      if (err) console.log(err, err.stack);
+    },
+    /* istanbul ignore next */
+    function(err, results) {
+      if (err) {
+        console.log(err, err.stack);
+      }
     });
   });
 }
 
 function invalidateCloudFront() {
   cloudfront.listDistributions(function(err, data) {
-    // Handle error
+    /* istanbul ignore next */
     if (err) {
       console.log(err, err.stack);
       return;
     }
 
     // Get distribution ID from domain name
-    var distributionID = data.Items.find(function (d) {
+    const distributionID = data.Items.find(function (d) {
       return d.DomainName == process.env.CLOUDFRONT_DISTRIBUTION_DOMAIN;
     }).Id;
 
@@ -232,8 +319,12 @@ function invalidateCloudFront() {
           ]
         }
       }
-    }, function(err, data) {
-      if (err) console.log(err, err.stack);
+    },
+    /* istanbul ignore next */
+    function(err, data) {
+      if (err) {
+        console.log(err, err.stack);
+      }
     });
   });
 }
@@ -247,7 +338,7 @@ function getAlbumMetadata(album, cb) {
       cb(null, null);
     } else {
       try {
-        var doc = yaml.safeLoad(data.Body.toString());
+        const doc = yaml.safeLoad(data.Body.toString());
         cb(null, doc);
       } catch (err) {
         cb(null, null);
@@ -256,50 +347,78 @@ function getAlbumMetadata(album, cb) {
   });
 }
 
-exports.handler = function(event, context) {
+function listAllContents(params) {
   // List all bucket objects
-  var params = {
-    Bucket: process.env.ORIGINAL_BUCKET
-  };
-  var allContents = [];
-  listAllContents();
-  function listAllContents() {
-    s3.listObjectsV2(params, function (err, data) {
-      if (err) {
-        console.log(err, err.stack); // an error occurred
-      } else {
-        var contents = data.Contents;
-        contents.forEach(function (content) {
-          allContents.push(content);
-        });
+  s3.listObjectsV2(params, function (err, data) {
+    /* istanbul ignore if */
+    if (err) {
+      console.log(err, err.stack); // an error occurred
+    }
+    else {
+      const allContents = [],
+            contents = data.Contents;
 
-        if (data.IsTruncated) {
-          params.ContinuationToken = data.NextContinuationToken;
-          //listAllContents();
-          console.log("S3 listing was truncated. Pausing 2 sec before continuing " + params.ContinuationToken );
-          setTimeout(listAllContents,2000); //rate limiting for reads - this is a tested safe value
-        }else{
+      contents.forEach(function (content) {
+        allContents.push(content);
+      });
 
-          // Parse albums
-          var albumsAndPictures = getAlbums(allContents);
-          console.log("First Album: "+albumsAndPictures.albums[albumsAndPictures.albums.length - 1]);
-          console.log("Last Album: "+albumsAndPictures.albums[0]);
-  
-          // Get metadata for all albums
-          async.map(albumsAndPictures.albums, getAlbumMetadata, function(err, metadata) {
+      if (data.IsTruncated) {
+        const newParams = {};
+        Object.assign(newParams, params);
+
+        const token = data.NextContinuationToken
+        newParams.ContinuationToken = token;
+        console.log(
+          "S3 listing was truncated. Pausing 2 sec before continuing " +
+          token
+        );
+        // Rate limiting for reads - this is a tested safe value
+        setTimeout(
+          function() {
+            listAllContents(newParams);
+          },
+          2000
+        );
+      }
+      else {
+        // Parse albums
+        const albumsAndPictures = getAlbums(allContents);
+        console.log(
+          "First Album: " +
+          albumsAndPictures.albums[albumsAndPictures.albums.length - 1]
+        );
+        console.log("Last Album: " + albumsAndPictures.albums[0]);
+
+        // Get metadata for all albums
+        async.map(
+          albumsAndPictures.albums,
+          getAlbumMetadata,
+          function(err, metadata) {
             // Upload homepage site
-            uploadHomepageSite(albumsAndPictures.albums, albumsAndPictures.pictures, metadata);
-  
+            uploadHomepageSite(
+              albumsAndPictures.albums, albumsAndPictures.pictures, metadata
+            );
+
             // Upload album sites
-            for (var i = albumsAndPictures.albums.length - 1; i >= 0; i--) {
-              uploadAlbumSite(albumsAndPictures.albums[i], albumsAndPictures.pictures[i], metadata[i]);
+            for (let i = albumsAndPictures.albums.length - 1; i >= 0; i--) {
+              uploadAlbumSite(
+                albumsAndPictures.albums[i],
+                albumsAndPictures.pictures[i],
+                metadata[i]
+              );
             }
-  
+
             // Invalidate CloudFront
             invalidateCloudFront();
-          });
-        }
+          }
+        );
       }
-    });
-  }
+    }
+  });
+}
+
+exports.handler = function(event, context) {
+  listAllContents({
+    Bucket: process.env.ORIGINAL_BUCKET
+  });
 };

--- a/test/sitebuilder/folderName.spec.js
+++ b/test/sitebuilder/folderName.spec.js
@@ -1,0 +1,49 @@
+const chai = require('chai');
+const mock = require('mock-require');
+const rewire = require('rewire');
+
+const expect = chai.expect;
+
+describe('siteBuilder folderName', function() {
+  let siteBuilder;
+  let folderName;
+
+  before(function() {
+    mock('aws-sdk', {
+      CloudFront: function() {},
+      S3: function() {}
+    });
+
+    siteBuilder = rewire('../../site-builder/index');
+
+    folderName = siteBuilder.__get__('folderName');
+  });
+
+  it('gets string before first slash', function() {
+    expect(folderName('folderfoo/filefoo')).to.equal('folderfoo');
+  });
+
+  it('gets string before first of many slashes', function() {
+    expect(folderName('folder1/folder2/folder3/filefoo')).to.equal('folder1');
+  });
+
+  it('gets nothing if nothing before first slash', function() {
+    expect(folderName('/somepath')).to.equal('');
+  });
+
+  it('gets nothing if passed nothing', function() {
+    expect(folderName('')).to.equal('');
+  });
+
+  it('leaves string un-modified if no slash', function() {
+    expect(folderName('somepath')).to.equal('somepath');
+  });
+
+  it('raises error if passed null', function() {
+    expect(function() { folderName(null); }).to.throw(TypeError);
+  });
+
+  after(function() {
+    mock.stop('aws-sdk');
+  });
+});

--- a/test/sitebuilder/getAlbumMetadata.spec.js
+++ b/test/sitebuilder/getAlbumMetadata.spec.js
@@ -1,0 +1,93 @@
+const chai = require('chai');
+const mock = require('mock-require');
+const rewire = require('rewire');
+
+const expect = chai.expect;
+
+describe('siteBuilder getAlbumMetadata', function() {
+  let siteBuilder;
+  let getAlbumMetadata;
+
+  before(function() {
+    mock('aws-sdk', {
+      CloudFront: function() {},
+      S3: function() {
+        return {
+          getObject: function(params, cb) {
+            const bucket = params.Bucket;
+            const key = params.Key;
+
+            if (bucket !== 'johnnyphotos') {
+              cb(null, null);
+            }
+            else if (key.includes('bobsbirthday')) {
+              cb(null, {Body: "title: Bob's Birthday"});
+            }
+            else if (key.includes('megsbirthday')) {
+              cb(null, 'badyaml');
+            }
+            else {
+              cb(true, null);
+            }
+          }
+        };
+      }
+    });
+
+    siteBuilder = rewire('../../site-builder/index');
+
+    getAlbumMetadata = siteBuilder.__get__('getAlbumMetadata');
+
+    process.env.ORIGINAL_BUCKET = 'johnnyphotos';
+  });
+
+  it('gets metadata for specified album', function() {
+    let metadata;
+
+    getAlbumMetadata('bobsbirthday', function(err, doc) {
+      metadata = doc;
+    });
+
+    expect(metadata).to.eql({title: "Bob's Birthday"});
+  });
+
+  it('gets nothing for album with invalid metadata', function() {
+    let metadata;
+
+    getAlbumMetadata('megsbirthday', function(err, doc) {
+      metadata = doc;
+    });
+
+    expect(metadata).to.be.a('null');
+  });
+
+  it('gets nothing for album with no metadata', function() {
+    let metadata;
+
+    getAlbumMetadata('suesbirthday', function(err, doc) {
+      metadata = doc;
+    });
+
+    expect(metadata).to.be.a('null');
+  });
+
+  it('gets nothing for wrong bucket', function() {
+    let metadata;
+
+    process.env.ORIGINAL_BUCKET = 'jimmyphotos';
+
+    getAlbumMetadata('bobsbirthday', function(err, doc) {
+      metadata = doc;
+    });
+
+    expect(metadata).to.be.a('null');
+
+    process.env.ORIGINAL_BUCKET = 'johnnyphotos';
+  });
+
+  after(function() {
+    mock.stop('aws-sdk');
+
+    delete process.env.ORIGINAL_BUCKET;
+  });
+});

--- a/test/sitebuilder/getAlbums.spec.js
+++ b/test/sitebuilder/getAlbums.spec.js
@@ -1,0 +1,77 @@
+const chai = require('chai');
+const mock = require('mock-require');
+const rewire = require('rewire');
+
+const expect = chai.expect;
+
+describe('siteBuilder getAlbums', function() {
+  let siteBuilder;
+  let getAlbums;
+
+  before(function() {
+    mock('aws-sdk', {
+      CloudFront: function() {},
+      S3: function() {}
+    });
+
+    siteBuilder = rewire('../../site-builder/index');
+
+    getAlbums = siteBuilder.__get__('getAlbums');
+  });
+
+  it('returns albums and pictures from input data', function() {
+    const data = [
+      {Key: 'california2020/disneyland.jpg', LastModified: 20200106090000},
+      {Key: 'california2020/napa.jpg', LastModified: 20200101090000},
+      {Key: 'bluemtns2020/threesisters.png'},
+      {Key: 'bluemtns2020/blackheath.jpg', LastModified: 20200102090000},
+      {Key: 'bluemtns2020/jenolancaves.jpg', LastModified: null},
+      {Key: 'funnyalbum/funnyfile.txt', LastModified: 20200109090000}
+    ];
+    const expectedAlbumsAndPictures = {
+      albums: [
+        'california2020',
+        'bluemtns2020',
+        'funnyalbum'
+      ],
+      pictures: [
+        [
+          'california2020/disneyland.jpg',
+          'california2020/napa.jpg'
+        ],
+        [
+          'bluemtns2020/threesisters.png',
+          'bluemtns2020/blackheath.jpg',
+          'bluemtns2020/jenolancaves.jpg'
+        ],
+        []
+      ]
+    };
+    expect(getAlbums(data)).to.eql(expectedAlbumsAndPictures);
+  });
+
+  it('returns empty lists from empty input', function() {
+    expect(getAlbums([])).to.eql({albums: [], pictures: []});
+  });
+
+  it('raises error if passed null', function() {
+    expect(function() { getAlbums(null); }).to.throw(TypeError);
+  });
+
+  it('raises error if array element is null', function() {
+    expect(function() { getAlbums([null]); }).to.throw(TypeError);
+  });
+
+  it('raises error if array element is empty object', function() {
+    expect(function() { getAlbums([{}]); }).to.throw(TypeError);
+  });
+
+  it('raises error if array element missing Key', function() {
+    expect(function() { getAlbums([{LastModified: 'yesterday'}]); })
+      .to.throw(TypeError);
+  });
+
+  after(function() {
+    mock.stop('aws-sdk');
+  });
+});

--- a/test/sitebuilder/invalidateCloudFront.spec.js
+++ b/test/sitebuilder/invalidateCloudFront.spec.js
@@ -1,0 +1,71 @@
+const chai = require('chai');
+const mock = require('mock-require');
+const rewire = require('rewire');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+
+chai.use(sinonChai);
+const expect = chai.expect;
+
+describe('siteBuilder invalidateCloudFront', function() {
+  let createInvalidationFake;
+  let siteBuilder;
+  let invalidateCloudFront;
+
+  before(function() {
+    createInvalidationFake = sinon.fake();
+    mock('aws-sdk', {
+      CloudFront: function() {
+        return {
+          listDistributions: function(cb) {
+            cb(null, {
+              Items: [
+                {Id: 111, DomainName: 'philharmonicphotos.com'},
+                {Id: 222, DomainName: 'johnnyphotos.com'}
+              ]
+            });
+          },
+          createInvalidation: createInvalidationFake
+        };
+      },
+      S3: function() {}
+    });
+
+    siteBuilder = rewire('../../site-builder/index');
+
+    invalidateCloudFront = siteBuilder.__get__('invalidateCloudFront');
+
+    process.env.CLOUDFRONT_DISTRIBUTION_DOMAIN = 'johnnyphotos.com';
+  });
+
+  it('invalidates the cloudfront distribution for configured domain', function() {
+    sinon.resetHistory();
+    const originalDateNow = Date.now;
+    Date.now = function() {
+      return 12345;
+    };
+
+    invalidateCloudFront();
+
+    expect(createInvalidationFake).to.have.callCount(1);
+
+    expect(createInvalidationFake).to.have.been.calledWith({
+      DistributionId: 222,
+      InvalidationBatch: {
+        CallerReference: 'site-builder-12345',
+        Paths: {
+          Quantity: 1,
+          Items: ['/*']
+        }
+      }
+    });
+
+    Date.now = originalDateNow;
+  });
+
+  after(function() {
+    mock.stop('aws-sdk');
+
+    delete process.env.CLOUDFRONT_DISTRIBUTION_DOMAIN;
+  });
+});

--- a/test/sitebuilder/isEmpty.spec.js
+++ b/test/sitebuilder/isEmpty.spec.js
@@ -1,0 +1,46 @@
+const chai = require('chai');
+const mock = require('mock-require');
+const rewire = require('rewire');
+
+const expect = chai.expect;
+
+describe('siteBuilder isEmpty', function() {
+  let siteBuilder;
+  let isEmpty;
+
+  before(function() {
+    mock('aws-sdk', {
+      CloudFront: function() {},
+      S3: function() {}
+    });
+
+    siteBuilder = rewire('../../site-builder/index');
+
+    isEmpty = siteBuilder.__get__('isEmpty');
+  });
+
+  it('returns true if object is empty', function() {
+    expect(isEmpty({})).to.be.true;
+  });
+
+  it('returns false if object is not empty', function() {
+    expect(isEmpty({foo: 'hoo'})).to.be.false;
+  });
+
+  it('returns true if hasOwnProperty is hacked up', function() {
+    expect(isEmpty({
+      hasOwnProperty: function() {
+        return false;
+      },
+      bar: 'Here be dragons'
+    })).to.be.true;
+  });
+
+  it('returns true if passed null', function() {
+    expect(isEmpty(null)).to.be.true;
+  });
+
+  after(function() {
+    mock.stop('aws-sdk');
+  });
+});

--- a/test/sitebuilder/listAllContents.spec.js
+++ b/test/sitebuilder/listAllContents.spec.js
@@ -1,0 +1,338 @@
+const chai = require('chai');
+const mock = require('mock-require');
+const rewire = require('rewire');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+
+chai.use(sinonChai);
+const expect = chai.expect;
+
+describe('siteBuilder listAllContents', function() {
+  let siteBuilder;
+  let handler;
+  let putObjectFake;
+  let clock;
+
+  before(function() {
+    putObjectFake = sinon.fake();
+    mock('aws-sdk', {
+      CloudFront: function() {},
+      S3: function() { return {
+        listObjectsV2: function(params, cb) {
+          if (params.ContinuationToken) {
+            cb(null, {Contents: [
+              {Key: 'bananasinbahamas/bananas.jpg', LastModified: 20180808080000},
+              {Key: 'bananasinbahamas/bahamas.jpg', LastModified: 20180808030000},
+              {Key: 'carrotsincuba/carrots.jpg', LastModified: 20180808050000},
+              {Key: 'carrotsincuba/cuba.jpg', LastModified: 20180808020000},
+              {Key: 'carrotsincuba/havana.jpg', LastModified: 20180808090000}
+            ]});
+          }
+          else {
+            cb(null, {
+              Contents: [],
+              IsTruncated: true,
+              NextContinuationToken: 999
+            });
+          }
+        },
+        getObject: function(params, cb) {
+          const key = params.Key;
+
+          if (key.includes('bananasinbahamas')) {
+            cb(null, {Body: (
+              'title: Bananas in Bahamas\n' +
+              'comment1: Oh the sunshine\n' +
+              'comment2: Upon my pineapple\n'
+            )});
+          }
+          else {
+            cb(true, null);
+          }
+        },
+        putObject: putObjectFake
+      }; }
+    });
+
+    mock('fs', {readFileSync: function(f) {
+      if (f.includes('homepage/index.html')) {
+        return (
+          '<html>\n' +
+          '<head>\n' +
+          '{googletracking}\n' +
+          '<title>{title}</title>\n' +
+          '</head>\n' +
+          '<body>\n' +
+          '<h1>{title}</h1>\n' +
+          '{pictures}\n' +
+          '</body>\n' +
+          '</html>\n'
+        );
+      }
+      else if (f.includes('error.html')) {
+        return (
+          '<html>\n' +
+          '<head>\n' +
+          '{googletracking}\n' +
+          '<title>Error</title>\n' +
+          '</head>\n' +
+          '<body>\n' +
+          '<h1>Error</h1>\n' +
+          '<form action="https://{website}/Prod/login"></form>\n' +
+          '</body>\n' +
+          '</html>\n'
+        );
+      }
+      else if (f.includes('album/index.html')) {
+        return (
+          '<html>\n' +
+          '<head>\n' +
+          '{googletracking}\n' +
+          '<title>{title}</title>\n' +
+          '</head>\n' +
+          '<body>\n' +
+          '<h1>{title}</h1>\n' +
+          '<p>{comment1}</p>\n' +
+          '<p>{comment2}</p>\n' +
+          '{pictures}\n' +
+          '</body>\n' +
+          '</html>\n'
+        );
+      }
+      else {
+        return 'lotsatext';
+      }
+    }});
+
+    clock = sinon.useFakeTimers();
+
+    siteBuilder = rewire('../../site-builder/index');
+
+    handler = siteBuilder.handler;
+
+    siteBuilder.__set__({
+      walk: function(dir, done) {
+        if (dir === 'homepage') {
+          return done(null, [
+            'homepage/index.html',
+            'homepage/error.html'
+          ]);
+        }
+        else {
+          return done(null, ['album/index.html']);
+        }
+      },
+      invalidateCloudFront: function() {},
+      delayBlock: function() {}
+    });
+
+    sinon.stub(console, 'log');
+
+    process.env.SITE_BUCKET = 'johnnyphotos';
+    process.env.WEBSITE = "johnnyphotos.com";
+    process.env.WEBSITE_TITLE = "Johnny's Awesome Photos";
+  });
+
+  it('publishes albums site based on pictures in source bucket', function() {
+    sinon.resetHistory();
+
+    handler(null, null);
+    clock.tick(2000);
+
+    const album1Markup = (
+      "\t\t\t\t\t\t<article class=\"thumb\">\n" +
+      "\t\t\t\t\t\t\t<a href=\"carrotsincuba/index.html\" class=\"image\">" +
+      "<img src=\"/pics/resized/1200x750/carrotsincuba/havana.jpg\" alt=\"\" />" +
+      "</a>\n" +
+      "\t\t\t\t\t\t\t<h2>carrotsincuba</h2>\n" +
+      "\t\t\t\t\t\t</article>"
+    );
+    const album2Markup = (
+      "\t\t\t\t\t\t<article class=\"thumb\">\n" +
+      "\t\t\t\t\t\t\t<a href=\"bananasinbahamas/index.html\" class=\"image\">" +
+      "<img src=\"/pics/resized/1200x750/bananasinbahamas/bananas.jpg\" alt=\"\" />" +
+      "</a>\n" +
+      "\t\t\t\t\t\t\t<h2>Bananas in Bahamas</h2>\n" +
+      "\t\t\t\t\t\t</article>"
+    );
+
+    const expectedIndexBody = (
+      '<html>\n' +
+      '<head>\n\n' +
+      "<title>Johnny's Awesome Photos</title>\n" +
+      '</head>\n' +
+      '<body>\n' +
+      "<h1>Johnny's Awesome Photos</h1>\n" +
+      album1Markup +
+      album2Markup + "\n" +
+      '</body>\n' +
+      '</html>\n'
+    );
+
+    const expectedErrorBody = (
+      '<html>\n' +
+      '<head>\n\n' +
+      '<title>Error</title>\n' +
+      '</head>\n' +
+      '<body>\n' +
+      '<h1>Error</h1>\n' +
+      '<form action="https://johnnyphotos.com/Prod/login"></form>\n' +
+      '</body>\n' +
+      '</html>\n'
+    );
+
+    const picture1Markup = (
+      "\t\t\t\t\t\t<article>\n" +
+      "\t\t\t\t\t\t\t" +
+      "<a class=\"thumbnail\" " +
+      "href=\"/pics/resized/1200x750/bananasinbahamas/bahamas.jpg\" " +
+      "data-position=\"center\">" +
+      "<img class=\"lazy\" src=\"assets/css/images/placeholder.png\" " +
+      "data-original=\"/pics/resized/360x225/bananasinbahamas/bahamas.jpg\" " +
+      "width=\"360\" height=\"225\"/></a>\n" +
+      "<p><a href=\"/pics/original/bananasinbahamas/bahamas.jpg\" download>" +
+      "High Resolution Download</a></p>\n" +
+      "\t\t\t\t\t\t</article>"
+    );
+    const picture2Markup = (
+      "\t\t\t\t\t\t<article>\n" +
+      "\t\t\t\t\t\t\t" +
+      "<a class=\"thumbnail\" " +
+      "href=\"/pics/resized/1200x750/bananasinbahamas/bananas.jpg\" " +
+      "data-position=\"center\">" +
+      "<img class=\"lazy\" src=\"assets/css/images/placeholder.png\" " +
+      "data-original=\"/pics/resized/360x225/bananasinbahamas/bananas.jpg\" " +
+      "width=\"360\" height=\"225\"/></a>\n" +
+      "<p><a href=\"/pics/original/bananasinbahamas/bananas.jpg\" download>" +
+      "High Resolution Download</a></p>\n" +
+      "\t\t\t\t\t\t</article>"
+    );
+
+    const expectedAlbum1IndexBody = (
+      '<html>\n' +
+      '<head>\n\n' +
+      '<title>Bananas in Bahamas</title>\n' +
+      '</head>\n' +
+      '<body>\n' +
+      '<h1>Bananas in Bahamas</h1>\n' +
+      '<p>Oh the sunshine</p>\n' +
+      '<p>Upon my pineapple</p>\n' +
+      picture1Markup +
+      picture2Markup + "\n" +
+      '</body>\n' +
+      '</html>\n'
+    );
+
+    const picture3Markup = (
+      "\t\t\t\t\t\t<article>\n" +
+      "\t\t\t\t\t\t\t" +
+      "<a class=\"thumbnail\" " +
+      "href=\"/pics/resized/1200x750/carrotsincuba/cuba.jpg\" " +
+      "data-position=\"center\">" +
+      "<img class=\"lazy\" src=\"assets/css/images/placeholder.png\" " +
+      "data-original=\"/pics/resized/360x225/carrotsincuba/cuba.jpg\" " +
+      "width=\"360\" height=\"225\"/></a>\n" +
+      "<p><a href=\"/pics/original/carrotsincuba/cuba.jpg\" download>" +
+      "High Resolution Download</a></p>\n" +
+      "\t\t\t\t\t\t</article>"
+    );
+    const picture4Markup = (
+      "\t\t\t\t\t\t<article>\n" +
+      "\t\t\t\t\t\t\t" +
+      "<a class=\"thumbnail\" " +
+      "href=\"/pics/resized/1200x750/carrotsincuba/carrots.jpg\" " +
+      "data-position=\"center\">" +
+      "<img class=\"lazy\" src=\"assets/css/images/placeholder.png\" " +
+      "data-original=\"/pics/resized/360x225/carrotsincuba/carrots.jpg\" " +
+      "width=\"360\" height=\"225\"/></a>\n" +
+      "<p><a href=\"/pics/original/carrotsincuba/carrots.jpg\" download>" +
+      "High Resolution Download</a></p>\n" +
+      "\t\t\t\t\t\t</article>"
+    );
+    const picture5Markup = (
+      "\t\t\t\t\t\t<article>\n" +
+      "\t\t\t\t\t\t\t" +
+      "<a class=\"thumbnail\" " +
+      "href=\"/pics/resized/1200x750/carrotsincuba/havana.jpg\" " +
+      "data-position=\"center\">" +
+      "<img class=\"lazy\" src=\"assets/css/images/placeholder.png\" " +
+      "data-original=\"/pics/resized/360x225/carrotsincuba/havana.jpg\" " +
+      "width=\"360\" height=\"225\"/></a>\n" +
+      "<p><a href=\"/pics/original/carrotsincuba/havana.jpg\" download>" +
+      "High Resolution Download</a></p>\n" +
+      "\t\t\t\t\t\t</article>"
+    );
+
+    const expectedAlbum2IndexBody = (
+      '<html>\n' +
+      '<head>\n\n' +
+      '<title>carrotsincuba</title>\n' +
+      '</head>\n' +
+      '<body>\n' +
+      '<h1>carrotsincuba</h1>\n' +
+      '<p></p>\n' +
+      '<p></p>\n' +
+      picture3Markup +
+      picture4Markup +
+      picture5Markup + "\n" +
+      '</body>\n' +
+      '</html>\n'
+    );
+
+    expect(putObjectFake).to.have.callCount(4);
+
+    expect(putObjectFake).to.have.been.calledWith({
+      Body: expectedIndexBody,
+      Bucket: 'johnnyphotos',
+      ContentType: 'text/html',
+      Key: 'index.html'
+    });
+
+    expect(putObjectFake).to.have.been.calledWith({
+      Body: expectedErrorBody,
+      Bucket: 'johnnyphotos',
+      ContentType: 'text/html',
+      Key: 'error.html'
+    });
+
+    expect(putObjectFake).to.have.been.calledWith({
+      Body: expectedAlbum1IndexBody,
+      Bucket: 'johnnyphotos',
+      ContentType: 'text/html',
+      Key: 'bananasinbahamas/index.html'
+    });
+
+    expect(putObjectFake).to.have.been.calledWith({
+      Body: expectedAlbum2IndexBody,
+      Bucket: 'johnnyphotos',
+      ContentType: 'text/html',
+      Key: 'carrotsincuba/index.html'
+    });
+
+    expect(console.log).to.have.callCount(5);
+    expect(console.log)
+      .to.have.been.calledWith(
+        'S3 listing was truncated. Pausing 2 sec before continuing 999'
+      );
+    expect(console.log)
+      .to.have.been.calledWith('First Album: bananasinbahamas');
+    expect(console.log)
+      .to.have.been.calledWith('Last Album: carrotsincuba');
+    expect(console.log)
+      .to.have.been.calledWith('Writing ALBUM bananasinbahamas');
+    expect(console.log)
+      .to.have.been.calledWith('Writing ALBUM carrotsincuba');
+  });
+
+  after(function() {
+    mock.stop('aws-sdk');
+    mock.stop('fs');
+
+    sinon.restore();
+    clock.restore();
+
+    delete process.env.SITE_BUCKET;
+    delete process.env.WEBSITE;
+    delete process.env.WEBSITE_TITLE;
+  });
+});

--- a/test/sitebuilder/stripPrefix.spec.js
+++ b/test/sitebuilder/stripPrefix.spec.js
@@ -1,0 +1,58 @@
+const chai = require('chai');
+const mock = require('mock-require');
+const rewire = require('rewire');
+
+const expect = chai.expect;
+
+describe('siteBuilder stripPrefix', function() {
+  let siteBuilder;
+  let stripPrefix;
+
+  before(function() {
+    mock('aws-sdk', {
+      CloudFront: function() {},
+      S3: function() {}
+    });
+
+    siteBuilder = rewire('../../site-builder/index');
+
+    stripPrefix = siteBuilder.__get__('stripPrefix');
+  });
+
+  it('removes pics/original/ if present at start of string', function() {
+    expect(stripPrefix({Key: 'pics/original/bla'})).to.equal('bla');
+  });
+
+  it('removes pics/original/ if present at end of string', function() {
+    expect(stripPrefix({Key: 'bla/pics/original/'})).to.equal('bla/');
+  });
+
+  it('removes pics/original/ if present in middle of string', function() {
+    expect(stripPrefix({Key: 'bla/pics/original/bla'})).to.equal('bla/bla');
+  });
+
+  it('removes only first instance of pics/original/ from string', function() {
+    expect(stripPrefix({Key: 'hoo/pics/original/haa/pics/original/bla'}))
+      .to.equal('hoo/haa/pics/original/bla');
+  });
+
+  it('leaves string un-modified if pics/original/ not present', function() {
+    expect(stripPrefix({Key: 'hoohaa'})).to.equal('hoohaa');
+  });
+
+  it('raises error if passed null', function() {
+    expect(function() { stripPrefix(null); }).to.throw(TypeError);
+  });
+
+  it('raises error if missing Key', function() {
+    expect(function() { stripPrefix({}); }).to.throw(TypeError);
+  });
+
+  it('raises error if Key is null', function() {
+    expect(function() { stripPrefix({Key: null}); }).to.throw(TypeError);
+  });
+
+  after(function() {
+    mock.stop('aws-sdk');
+  });
+});

--- a/test/sitebuilder/uploadAlbumSite.spec.js
+++ b/test/sitebuilder/uploadAlbumSite.spec.js
@@ -1,0 +1,267 @@
+const chai = require('chai');
+const mock = require('mock-require');
+const rewire = require('rewire');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+
+chai.use(sinonChai);
+const expect = chai.expect;
+
+describe('siteBuilder uploadAlbumSite', function() {
+  let ga;
+  let putObjectFake;
+  let siteBuilder;
+  let uploadAlbumSite;
+
+  before(function() {
+    putObjectFake = sinon.fake();
+    mock('aws-sdk', {
+      CloudFront: function() {},
+      S3: function() { return {putObject: putObjectFake}; }
+    });
+
+    mock('fs', {readFileSync: function(f) {
+      if (f.includes('index.html')) {
+        return (
+          '<html>\n' +
+          '<head>\n' +
+          '{googletracking}\n' +
+          '<title>{title}</title>\n' +
+          '</head>\n' +
+          '<body>\n' +
+          '<h1>{title}</h1>\n' +
+          '<p>{comment1}</p>\n' +
+          '<p>{comment2}</p>\n' +
+          '{pictures}\n' +
+          '</body>\n' +
+          '</html>\n'
+        );
+      }
+      else {
+        return 'lotsatext';
+      }
+    }});
+
+    siteBuilder = rewire('../../site-builder/index');
+
+    ga = siteBuilder.__get__('ga');
+    uploadAlbumSite = siteBuilder.__get__('uploadAlbumSite');
+
+    siteBuilder.__set__({
+      walk: function(dir, done) {
+        return done(null, [
+          'album/foo/boo.txt',
+          'album/index.html'
+        ]);
+      },
+      delayBlock: function() {}
+    });
+
+    sinon.stub(console, 'log');
+
+    process.env.GOOGLEANALYTICS = 'googleanalyticsfunkycode';
+    process.env.SITE_BUCKET = 'johnnyphotos';
+  });
+
+  it('uploads album files to s3', function() {
+    sinon.resetHistory();
+
+    uploadAlbumSite(
+      'summerinsicily',
+      [
+        'summerinsicily/agrigento.jpg',
+        'summerinsicily/taormina.jpg'
+      ],
+      {
+        title: 'Summer in Sicily',
+        comment1: 'With my cat',
+        comment2: 'And my llama'
+      }
+    );
+
+    const picture1Markup = (
+      "\t\t\t\t\t\t<article>\n" +
+      "\t\t\t\t\t\t\t" +
+      "<a class=\"thumbnail\" " +
+      "href=\"/pics/resized/1200x750/summerinsicily/taormina.jpg\" " +
+      "data-position=\"center\">" +
+      "<img class=\"lazy\" src=\"assets/css/images/placeholder.png\" " +
+      "data-original=\"/pics/resized/360x225/summerinsicily/taormina.jpg\" " +
+      "width=\"360\" height=\"225\"/></a>\n" +
+      "<p><a href=\"/pics/original/summerinsicily/taormina.jpg\" download>" +
+      "High Resolution Download</a></p>\n" +
+      "\t\t\t\t\t\t</article>"
+    );
+    const picture2Markup = (
+      "\t\t\t\t\t\t<article>\n" +
+      "\t\t\t\t\t\t\t" +
+      "<a class=\"thumbnail\" " +
+      "href=\"/pics/resized/1200x750/summerinsicily/agrigento.jpg\" " +
+      "data-position=\"center\">" +
+      "<img class=\"lazy\" src=\"assets/css/images/placeholder.png\" " +
+      "data-original=\"/pics/resized/360x225/summerinsicily/agrigento.jpg\" " +
+      "width=\"360\" height=\"225\"/></a>\n" +
+      "<p><a href=\"/pics/original/summerinsicily/agrigento.jpg\" download>" +
+      "High Resolution Download</a></p>\n" +
+      "\t\t\t\t\t\t</article>"
+    );
+
+    const expectedIndexBody = (
+      '<html>\n' +
+      '<head>\n' +
+      ga.replace(/\{gtag\}/g, 'googleanalyticsfunkycode') + '\n' +
+      '<title>Summer in Sicily</title>\n' +
+      '</head>\n' +
+      '<body>\n' +
+      '<h1>Summer in Sicily</h1>\n' +
+      '<p>With my cat</p>\n' +
+      '<p>And my llama</p>\n' +
+      picture1Markup +
+      picture2Markup + "\n" +
+      '</body>\n' +
+      '</html>\n'
+    );
+
+    const expectedErrorBody = (
+      '<html>\n' +
+      '<head>\n' +
+      ga.replace(/\{gtag\}/g, 'googleanalyticsfunkycode') + '\n' +
+      '<title>Error</title>\n' +
+      '</head>\n' +
+      '<body>\n' +
+      '<h1>Error</h1>\n' +
+      '<form action="https://johnnyphotos.com/Prod/login"></form>\n' +
+      '</body>\n' +
+      '</html>\n'
+    );
+
+    expect(putObjectFake).to.have.callCount(2);
+    expect(console.log)
+      .to.have.been.calledWith('Writing ALBUM summerinsicily');
+
+    expect(putObjectFake).to.have.been.calledWith({
+      Body: 'lotsatext',
+      Bucket: 'johnnyphotos',
+      ContentType: 'text/plain',
+      Key: 'summerinsicily/foo/boo.txt'
+    });
+
+    expect(putObjectFake).to.have.been.calledWith({
+      Body: expectedIndexBody,
+      Bucket: 'johnnyphotos',
+      ContentType: 'text/html',
+      Key: 'summerinsicily/index.html'
+    });
+  });
+
+  it('omits google analytics markup if no tracking code configured', function() {
+    sinon.resetHistory();
+    delete process.env.GOOGLEANALYTICS;
+
+    uploadAlbumSite(
+      null,
+      [
+        'summerinsicily/agrigento.jpg',
+        'summerinsicily/taormina.jpg'
+      ],
+      {someIgnoredMetadata: 123}
+    );
+
+    const picture1Markup = (
+      "\t\t\t\t\t\t<article>\n" +
+      "\t\t\t\t\t\t\t" +
+      "<a class=\"thumbnail\" " +
+      "href=\"/pics/resized/1200x750/summerinsicily/taormina.jpg\" " +
+      "data-position=\"center\">" +
+      "<img class=\"lazy\" src=\"assets/css/images/placeholder.png\" " +
+      "data-original=\"/pics/resized/360x225/summerinsicily/taormina.jpg\" " +
+      "width=\"360\" height=\"225\"/></a>\n" +
+      "<p><a href=\"/pics/original/summerinsicily/taormina.jpg\" download>" +
+      "High Resolution Download</a></p>\n" +
+      "\t\t\t\t\t\t</article>"
+    );
+    const picture2Markup = (
+      "\t\t\t\t\t\t<article>\n" +
+      "\t\t\t\t\t\t\t" +
+      "<a class=\"thumbnail\" " +
+      "href=\"/pics/resized/1200x750/summerinsicily/agrigento.jpg\" " +
+      "data-position=\"center\">" +
+      "<img class=\"lazy\" src=\"assets/css/images/placeholder.png\" " +
+      "data-original=\"/pics/resized/360x225/summerinsicily/agrigento.jpg\" " +
+      "width=\"360\" height=\"225\"/></a>\n" +
+      "<p><a href=\"/pics/original/summerinsicily/agrigento.jpg\" download>" +
+      "High Resolution Download</a></p>\n" +
+      "\t\t\t\t\t\t</article>"
+    );
+
+    const expectedIndexBody = (
+      '<html>\n' +
+      '<head>\n\n' +
+      '<title>null</title>\n' +
+      '</head>\n' +
+      '<body>\n' +
+      '<h1>null</h1>\n' +
+      '<p></p>\n' +
+      '<p></p>\n' +
+      picture1Markup +
+      picture2Markup + "\n" +
+      '</body>\n' +
+      '</html>\n'
+    );
+
+    const expectedErrorBody = (
+      '<html>\n' +
+      '<head>\n\n' +
+      '<title>Error</title>\n' +
+      '</head>\n' +
+      '<body>\n' +
+      '<h1>Error</h1>\n' +
+      '<form action="https://johnnyphotos.com/Prod/login"></form>\n' +
+      '</body>\n' +
+      '</html>\n'
+    );
+
+    expect(putObjectFake).to.have.callCount(2);
+    expect(console.log)
+      .to.have.been.calledWith('Writing ALBUM null');
+
+    expect(putObjectFake).to.have.been.calledWith({
+      Body: 'lotsatext',
+      Bucket: 'johnnyphotos',
+      ContentType: 'text/plain',
+      Key: 'null/foo/boo.txt'
+    });
+
+    expect(putObjectFake).to.have.been.calledWith({
+      Body: expectedIndexBody,
+      Bucket: 'johnnyphotos',
+      ContentType: 'text/html',
+      Key: 'null/index.html'
+    });
+
+    process.env.GOOGLEANALYTICS = 'googleanalyticsfunkycode';
+  });
+
+  it('raises error if pictures is null', function() {
+    expect(function() {
+      uploadAlbumSite(
+        'summerinsicily', null,
+        {
+          title: 'Summer in Sicily',
+          comment1: 'With my cat',
+          comment2: 'And my llama'
+        }
+      );
+    }).to.throw(TypeError);
+  });
+
+  after(function() {
+    mock.stop('aws-sdk');
+    mock.stop('fs');
+
+    sinon.restore();
+
+    delete process.env.GOOGLEANALYTICS;
+    delete process.env.SITE_BUCKET;
+  });
+});

--- a/test/sitebuilder/uploadHomepageSite.spec.js
+++ b/test/sitebuilder/uploadHomepageSite.spec.js
@@ -1,0 +1,266 @@
+const chai = require('chai');
+const mock = require('mock-require');
+const rewire = require('rewire');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+
+chai.use(sinonChai);
+const expect = chai.expect;
+
+describe('siteBuilder uploadHomepageSite', function() {
+  let ga;
+  let putObjectFake;
+  let siteBuilder;
+  let uploadHomepageSite;
+
+  before(function() {
+    putObjectFake = sinon.fake();
+    mock('aws-sdk', {
+      CloudFront: function() {},
+      S3: function() { return {putObject: putObjectFake}; }
+    });
+
+    mock('fs', {readFileSync: function(f) {
+      if (f.includes('index.html')) {
+        return (
+          '<html>\n' +
+          '<head>\n' +
+          '{googletracking}\n' +
+          '<title>{title}</title>\n' +
+          '</head>\n' +
+          '<body>\n' +
+          '<h1>{title}</h1>\n' +
+          '{pictures}\n' +
+          '</body>\n' +
+          '</html>\n'
+        );
+      }
+      else if (f.includes('error.html')) {
+        return (
+          '<html>\n' +
+          '<head>\n' +
+          '{googletracking}\n' +
+          '<title>Error</title>\n' +
+          '</head>\n' +
+          '<body>\n' +
+          '<h1>Error</h1>\n' +
+          '<form action="https://{website}/Prod/login"></form>\n' +
+          '</body>\n' +
+          '</html>\n'
+        );
+      }
+      else {
+        return 'lotsatext';
+      }
+    }});
+
+    siteBuilder = rewire('../../site-builder/index');
+
+    ga = siteBuilder.__get__('ga');
+    uploadHomepageSite = siteBuilder.__get__('uploadHomepageSite');
+
+    siteBuilder.__set__({walk: function(dir, done) {
+      return done(null, [
+        'homepage/foo/hoo.txt',
+        'homepage/index.html',
+        'homepage/error.html'
+      ]);
+    }});
+
+    process.env.GOOGLEANALYTICS = 'googleanalyticsfunkycode';
+    process.env.SITE_BUCKET = 'johnnyphotos';
+    process.env.WEBSITE = "johnnyphotos.com";
+    process.env.WEBSITE_TITLE = "Johnny's Awesome Photos";
+  });
+
+  it('uploads homepage files to s3', function() {
+    sinon.resetHistory();
+
+    uploadHomepageSite(
+      [
+        'california2020',
+        'bluemtns2020'
+      ],
+      [
+        [
+          'california2020/disneyland.jpg',
+          'california2020/napa.jpg'
+        ],
+        [
+          'bluemtns2020/threesisters.png',
+          'bluemtns2020/blackheath.jpg',
+          'bluemtns2020/jenolancaves.jpg'
+        ]
+      ],
+      [{title: 'California 2020'}]
+    );
+
+    const album1Markup = (
+      "\t\t\t\t\t\t<article class=\"thumb\">\n" +
+      "\t\t\t\t\t\t\t<a href=\"california2020/index.html\" class=\"image\">" +
+      "<img src=\"/pics/resized/1200x750/california2020/disneyland.jpg\" alt=\"\" />" +
+      "</a>\n" +
+      "\t\t\t\t\t\t\t<h2>California 2020</h2>\n" +
+      "\t\t\t\t\t\t</article>"
+    );
+    const album2Markup = (
+      "\t\t\t\t\t\t<article class=\"thumb\">\n" +
+      "\t\t\t\t\t\t\t<a href=\"bluemtns2020/index.html\" class=\"image\">" +
+      "<img src=\"/pics/resized/1200x750/bluemtns2020/threesisters.png\" alt=\"\" />" +
+      "</a>\n" +
+      "\t\t\t\t\t\t\t<h2>bluemtns2020</h2>\n" +
+      "\t\t\t\t\t\t</article>"
+    );
+
+    const expectedIndexBody = (
+      '<html>\n' +
+      '<head>\n' +
+      ga.replace(/\{gtag\}/g, 'googleanalyticsfunkycode') + '\n' +
+      "<title>Johnny's Awesome Photos</title>\n" +
+      '</head>\n' +
+      '<body>\n' +
+      "<h1>Johnny's Awesome Photos</h1>\n" +
+      album1Markup +
+      album2Markup + "\n" +
+      '</body>\n' +
+      '</html>\n'
+    );
+
+    const expectedErrorBody = (
+      '<html>\n' +
+      '<head>\n' +
+      ga.replace(/\{gtag\}/g, 'googleanalyticsfunkycode') + '\n' +
+      '<title>Error</title>\n' +
+      '</head>\n' +
+      '<body>\n' +
+      '<h1>Error</h1>\n' +
+      '<form action="https://johnnyphotos.com/Prod/login"></form>\n' +
+      '</body>\n' +
+      '</html>\n'
+    );
+
+    expect(putObjectFake).to.have.callCount(3);
+
+    expect(putObjectFake).to.have.been.calledWith({
+      Body: 'lotsatext',
+      Bucket: 'johnnyphotos',
+      ContentType: 'text/plain',
+      Key: 'foo/hoo.txt'
+    });
+
+    expect(putObjectFake).to.have.been.calledWith({
+      Body: expectedIndexBody,
+      Bucket: 'johnnyphotos',
+      ContentType: 'text/html',
+      Key: 'index.html'
+    });
+
+    expect(putObjectFake).to.have.been.calledWith({
+      Body: expectedErrorBody,
+      Bucket: 'johnnyphotos',
+      ContentType: 'text/html',
+      Key: 'error.html'
+    });
+  });
+
+  it('omits google analytics markup if no tracking code configured', function() {
+    sinon.resetHistory();
+    delete process.env.GOOGLEANALYTICS;
+
+    uploadHomepageSite(
+      ['bluemtns2020'], [['bluemtns2020/jenolancaves.jpg']], []
+    );
+
+    const albumMarkup = (
+      "\t\t\t\t\t\t<article class=\"thumb\">\n" +
+      "\t\t\t\t\t\t\t<a href=\"bluemtns2020/index.html\" class=\"image\">" +
+      "<img src=\"/pics/resized/1200x750/bluemtns2020/jenolancaves.jpg\" alt=\"\" />" +
+      "</a>\n" +
+      "\t\t\t\t\t\t\t<h2>bluemtns2020</h2>\n" +
+      "\t\t\t\t\t\t</article>"
+    );
+
+    const expectedIndexBody = (
+      '<html>\n' +
+      '<head>\n\n' +
+      "<title>Johnny's Awesome Photos</title>\n" +
+      '</head>\n' +
+      '<body>\n' +
+      "<h1>Johnny's Awesome Photos</h1>\n" +
+      albumMarkup + "\n" +
+      '</body>\n' +
+      '</html>\n'
+    );
+
+    const expectedErrorBody = (
+      '<html>\n' +
+      '<head>\n\n' +
+      '<title>Error</title>\n' +
+      '</head>\n' +
+      '<body>\n' +
+      '<h1>Error</h1>\n' +
+      '<form action="https://johnnyphotos.com/Prod/login"></form>\n' +
+      '</body>\n' +
+      '</html>\n'
+    );
+
+    expect(putObjectFake).to.have.callCount(3);
+
+    expect(putObjectFake).to.have.been.calledWith({
+      Body: 'lotsatext',
+      Bucket: 'johnnyphotos',
+      ContentType: 'text/plain',
+      Key: 'foo/hoo.txt'
+    });
+
+    expect(putObjectFake).to.have.been.calledWith({
+      Body: expectedIndexBody,
+      Bucket: 'johnnyphotos',
+      ContentType: 'text/html',
+      Key: 'index.html'
+    });
+
+    expect(putObjectFake).to.have.been.calledWith({
+      Body: expectedErrorBody,
+      Bucket: 'johnnyphotos',
+      ContentType: 'text/html',
+      Key: 'error.html'
+    });
+
+    process.env.GOOGLEANALYTICS = 'googleanalyticsfunkycode';
+  });
+
+  it('raises error if albums is null', function() {
+    expect(function() {
+      uploadHomepageSite(
+        null, [['bluemtns2020/jenolancaves.jpg']], []
+      );
+    }).to.throw(TypeError);
+  });
+
+  it('raises error if pictures is null', function() {
+    expect(function() {
+      uploadHomepageSite(
+        ['bluemtns2020'], null, []
+      );
+    }).to.throw(TypeError);
+  });
+
+  it('raises error if metadata is null', function() {
+    expect(function() {
+      uploadHomepageSite(
+        ['bluemtns2020'], [['bluemtns2020/jenolancaves.jpg']], null
+      );
+    }).to.throw(TypeError);
+  });
+
+  after(function() {
+    mock.stop('aws-sdk');
+    mock.stop('fs');
+
+    delete process.env.GOOGLEANALYTICS;
+    delete process.env.SITE_BUCKET;
+    delete process.env.WEBSITE;
+    delete process.env.WEBSITE_TITLE;
+  });
+});

--- a/test/sitebuilder/walk.spec.js
+++ b/test/sitebuilder/walk.spec.js
@@ -1,0 +1,87 @@
+const chai = require('chai');
+const mock = require('mock-require');
+const rewire = require('rewire');
+
+const expect = chai.expect;
+
+describe('siteBuilder walk', function() {
+  let siteBuilder;
+  let walk;
+
+  before(function() {
+    mock('aws-sdk', {
+      CloudFront: function() {},
+      S3: function() {}
+    });
+
+    mock('fs', {
+      readdir: function(dir, cb) {
+        if (dir == null || !dir.includes('foo')) {
+          cb(null, []);
+        }
+        else if (dir.includes('oink')) {
+          cb(null, ['quack.html']);
+        }
+        else if (dir.includes('baa')) {
+          cb(null, ['woof.csv']);
+        }
+        else {
+          cb(null, ['oink', 'baa.txt', 'moo.pdf', 'baa']);
+        }
+      },
+      stat: function(file, cb) {
+        cb(null, {isDirectory: function() { return file.indexOf('.') === -1; }});
+      }
+    });
+
+    siteBuilder = rewire('../../site-builder/index');
+
+    walk = siteBuilder.__get__('walk');
+  });
+
+  it('lists all files in a directory tree', function() {
+    let foundFiles;
+
+    walk('/foo', function(err, files) {
+      foundFiles = files;
+    });
+
+    const expectedFiles = [
+      '/foo/oink/quack.html',
+      '/foo/baa.txt',
+      '/foo/moo.pdf',
+      '/foo/baa/woof.csv',
+    ];
+
+    expect(foundFiles).to.eql(expectedFiles);
+  });
+
+  it('lists no files when directory is empty', function() {
+    let foundFiles;
+
+    walk('/oonga', function(err, files) {
+      foundFiles = files;
+    });
+
+    expect(foundFiles).to.be.empty;
+  });
+
+  it('lists no files if dir is null', function() {
+    let foundFiles;
+
+    walk(null, function(err, files) {
+      foundFiles = files;
+    });
+
+    expect(foundFiles).to.be.empty;
+  });
+
+  it('raises error if done is null', function() {
+    expect(function() { walk('/daffodils', null); }).to.throw(TypeError);
+  });
+
+  after(function() {
+    mock.stop('aws-sdk');
+    mock.stop('fs');
+  });
+});


### PR DESCRIPTION
- Mocha unit tests for all the code in `site-builder/index.js`
- Using Istanbul to confirm 100% coverage of that file (except for a few spots that I've marked to be ignored for coverage)
- Only formatting changes in `site-builder/index.js` (and some minor refactoring, that I only did after writing all the tests)
- Travis config file so these tests can run on every commit in AWSPics from now on, see successful test build that I triggered at https://travis-ci.com/github/Jaza/AWSPics/builds/198224105

Would be nice to also write tests for the other lambda files `resize/index.js` and `login/index.js` , I have just done the site builder for now.

Why did I bother doing all this, you ask? Because I'd like to make a few enhancements to the site builder, and I want to be confident that those enhancements don't break any existing functionality. Best way to do that is to put in place a safety net of high test coverage for the existing code.