### PR TITLE
Truncated S3 list objects response fix

### DIFF
--- a/test/site-builder/index.spec.js
+++ b/test/site-builder/index.spec.js
@@ -21,8 +21,6 @@ describe('index', function() {
           listObjectsV2: function(params, cb) {
             if (params.ContinuationToken) {
               cb(null, {Contents: [
-                {Key: 'originaljohnny/bananasinbahamas/bananas.jpg', LastModified: 20180808080000},
-                {Key: 'originaljohnny/bananasinbahamas/bahamas.jpg', LastModified: 20180808030000},
                 {Key: 'originaljohnny/carrotsincuba/carrots.jpg', LastModified: 20180808050000},
                 {Key: 'originaljohnny/carrotsincuba/cuba.jpg', LastModified: 20180808020000},
                 {Key: 'originaljohnny/carrotsincuba/havana.jpg', LastModified: 20180808090000}
@@ -30,7 +28,10 @@ describe('index', function() {
             }
             else {
               cb(null, {
-                Contents: [],
+                Contents: [
+                  {Key: 'originaljohnny/bananasinbahamas/bananas.jpg', LastModified: 20180808080000},
+                  {Key: 'originaljohnny/bananasinbahamas/bahamas.jpg', LastModified: 20180808030000}
+                ],
                 IsTruncated: true,
                 NextContinuationToken: 999
               });


### PR DESCRIPTION
Oops, turns out I broke the functionality of building up the `allContents` list across multiple `s3.listObjectsV2` calls, in the case where the S3 listing is truncated and we have to call it again.

Fixed it up, and changed a unit test so that it explicitly tests this case.