### PR TITLE
Make login page mobile friendly

### DIFF
--- a/site-builder/homepage/error.html
+++ b/site-builder/homepage/error.html
@@ -3,6 +3,7 @@
   <head>
     {googletracking}
     <meta charset="UTF-8">
+    <meta name='viewport' content='width=device-width, initial-scale=1'>
     <title>Error – Are You Logged In?</title>
     <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">


### PR DESCRIPTION
It's just missing the `meta name='viewport' tag` (which the original codepen HTML contains), to make it scale correctly on all devices.