### PR TITLE
Delay after each chunk of 100 albums

### DIFF
--- a/site-builder/lib/collectionPage.js
+++ b/site-builder/lib/collectionPage.js
@@ -103,7 +103,7 @@ function uploadCollection(
   collPictures,
   metadataForColl,
   metadataForAlbums,
-  isFirstAlbum
+  albumIndex
 ) {
   console.log(
     "First album in " + collection + ": " +
@@ -122,7 +122,7 @@ function uploadCollection(
     collection, collTitle, collAlbums, collPictures, metadataForAlbums
   );
 
-  let newIsFirstAlbum = isFirstAlbum;
+  let newAlbumIndex = albumIndex;
 
   // Upload album pages
   for (let i = collAlbums.length - 1; i >= 0; i--) {
@@ -132,13 +132,13 @@ function uploadCollection(
       metadataForAlbums[i],
       collection + '/index.html',
       collTitle,
-      newIsFirstAlbum
+      newAlbumIndex
     );
 
-    if (newIsFirstAlbum) {
-      newIsFirstAlbum = false;
-    }
+    newAlbumIndex += 1
   }
+
+  return newAlbumIndex;
 }
 
 function uploadCollections(
@@ -158,20 +158,18 @@ function uploadCollections(
     collMetadata
   );
 
-  let isFirstAlbum = true;
+  let albumIndex = 0;
 
   // Upload collection pages
   for (let i = collections.length - 1; i >= 0; i--) {
-    uploadCollection(
+    albumIndex = uploadCollection(
       collections[i],
       albumsByCollAndPictures.albumsByCollection[i].albums,
       albumsByCollAndPictures.pictures[i],
       collMetadata[i],
       albumMetadata[i],
-      isFirstAlbum
+      albumIndex
     );
-
-    isFirstAlbum = false;
   }
 
   // Invalidate CloudFront

--- a/test/site-builder/albumPage.spec.js
+++ b/test/site-builder/albumPage.spec.js
@@ -10,6 +10,7 @@ const expect = chai.expect;
 describe('albumPage', function() {
   describe('uploadAlbumPage', function() {
     let putObjectFake;
+    let delayBlockFake;
     let albumPage;
 
     before(function() {
@@ -64,8 +65,9 @@ describe('albumPage', function() {
         }
       });
 
+      delayBlockFake = sinon.fake();
       mock('../../site-builder/lib/delayUtils', {
-        delayBlock: function() {}
+        delayBlock: delayBlockFake
       });
 
       albumPage = rewire('../../site-builder/lib/albumPage');
@@ -142,6 +144,8 @@ describe('albumPage', function() {
         ContentType: 'text/html',
         Key: 'summerinsicily/index.html'
       });
+
+      expect(delayBlockFake.called).to.be.false;
     });
 
     it('omits google analytics markup if no tracking code configured', function() {
@@ -156,7 +160,10 @@ describe('albumPage', function() {
           'summerinsicily/taormina.jpg',
           'summerinsicily/agrigento.jpg'
         ],
-        {someIgnoredMetadata: 123}
+        {someIgnoredMetadata: 123},
+        null,
+        null,
+        500
       );
 
       const picture1Markup = (
@@ -192,6 +199,9 @@ describe('albumPage', function() {
       );
 
       expect(putObjectFake).to.have.callCount(2);
+      expect(console.log).to.have.been.calledWith(
+        "Written 500 albums, forcing a short delay before continuing"
+      );
       expect(console.log)
         .to.have.been.calledWith('Writing album null');
 
@@ -208,6 +218,8 @@ describe('albumPage', function() {
         ContentType: 'text/html',
         Key: 'null/index.html'
       });
+
+      expect(delayBlockFake.called).to.be.true;
 
       process.env.GOOGLEANALYTICS = 'googleanalyticsfunkycode';
       delete process.env.SPACES_INSTEAD_OF_TABS;


### PR DESCRIPTION
Now that we're only pushing the album assets once, not per album, we're only pushing one file - index.html - for all albums after the first one. So we can get away with a lot less delay, and still stay below the 3500 writes/second rate limit for S3. Delaying after each 100 albums should be enough.