### PR TITLE
Collection descriptions

### DIFF
--- a/site-builder/album/index.html
+++ b/site-builder/album/index.html
@@ -15,8 +15,8 @@
       <div id="main">
           <header id="header">
             <h1>{title}</h1>
-            <p>{comment1}</p>
-            <p>{comment2}</p>
+{comment1}
+{comment2}
             <p><a href="/{parentLink}">Back to {parentTitle}.</a></p>
           </header>
           <section id="thumbnails">

--- a/site-builder/homepage/index.html
+++ b/site-builder/homepage/index.html
@@ -14,11 +14,12 @@
       <div id="wrapper">
           <header id="header">
             <h1><strong>{title}</strong></h1>
-{backTo}
+{nav}
           </header>
           <div id="main">
 {pictures}
           </div>
+{footer}
       </div>
       <script src="/assets/homepage/js/jquery.min.js"></script>
       <script src="/assets/homepage/js/skel.min.js"></script>

--- a/site-builder/homepage/snippets/footer.html
+++ b/site-builder/homepage/snippets/footer.html
@@ -1,0 +1,7 @@
+          <footer id="footer" class="panel">
+            <div class="inner">
+              <section>
+{footerContent}
+              </section>
+            </div>
+          </footer>

--- a/site-builder/homepage/snippets/nav.html
+++ b/site-builder/homepage/snippets/nav.html
@@ -1,7 +1,7 @@
             <nav>
               <ul>
                 <li>
-{backLink}
+{navLink}
                 </li>
               </ul>
             </nav>

--- a/site-builder/lib/albumPage.js
+++ b/site-builder/lib/albumPage.js
@@ -33,10 +33,10 @@ function getAlbumPageBody(
       renderedTitle = metadata.title;
     }
     if (metadata.comment1) {
-      comment1 = metadata.comment1;
+      comment1 = '<p>' + metadata.comment1 + '</p>';
     }
     if (metadata.comment2) {
-      comment2 = metadata.comment2;
+      comment2 = '<p>' + metadata.comment2 + '</p>';
     }
   }
 

--- a/site-builder/lib/collectionPage.js
+++ b/site-builder/lib/collectionPage.js
@@ -54,7 +54,9 @@ function unflattenAlbumMetadataForCollections(
   return albumMetadata;
 }
 
-function uploadCollectionPage(collectionName, title, albums, pictures, metadata) {
+function uploadCollectionPage(
+  collectionName, title, comment1, comment2, albums, pictures, metadata
+) {
   const dir = 'homepage';
   console.log("Writing collection " + collectionName);
 
@@ -68,14 +70,25 @@ function uploadCollectionPage(collectionName, title, albums, pictures, metadata)
     const ga = fs.readFileSync('shared/snippets/ga.html').toString();
 
     const albumMarkup = fs.readFileSync('homepage/snippets/album.html').toString();
-    const backTo = fs.readFileSync('homepage/snippets/backto.html').toString();
+    const nav = fs.readFileSync('homepage/snippets/nav.html').toString();
+    const footer = fs.readFileSync('homepage/snippets/footer.html').toString();
 
     async.map(files, function(f, cb) {
       const filePath = path.relative(dir, f);
       if (filePath.includes('index.html')) {
         const data = fs.readFileSync(f);
         const body = homePage.getHomePageBody(
-          data, albums, pictures, metadata, albumMarkup, ga, backTo, title
+          data,
+          albums,
+          pictures,
+          metadata,
+          albumMarkup,
+          ga,
+          nav,
+          footer,
+          title,
+          comment1,
+          comment2
         );
 
         const options = {
@@ -117,9 +130,21 @@ function uploadCollection(
   const collTitle = (metadataForColl && metadataForColl.title) ?
     metadataForColl.title :
     collection;
+  const collComment1 = (metadataForColl && metadataForColl.comment1) ?
+    metadataForColl.comment1 :
+    null;
+  const collComment2 = (metadataForColl && metadataForColl.comment2) ?
+    metadataForColl.comment2 :
+    null;
 
   uploadCollectionPage(
-    collection, collTitle, collAlbums, collPictures, metadataForAlbums
+    collection,
+    collTitle,
+    collComment1,
+    collComment2,
+    collAlbums,
+    collPictures,
+    metadataForAlbums
   );
 
   let newAlbumIndex = albumIndex;

--- a/site-builder/lib/homePage.js
+++ b/site-builder/lib/homePage.js
@@ -32,7 +32,17 @@ function getErrorPageBody(data, ga) {
 }
 
 const getHomePageBody = exports.getHomePageBody = function(
-  data, albums, pictures, metadata, albumMarkup, ga, backTo, title
+  data,
+  albums,
+  pictures,
+  metadata,
+  albumMarkup,
+  ga,
+  nav,
+  footer,
+  title,
+  comment1,
+  comment2
 ) {
   let picturesHTML = '';
   const albumsPicturesMetadata = albums.map(function(album, i) {
@@ -55,35 +65,64 @@ const getHomePageBody = exports.getHomePageBody = function(
   }
 
   const pageTitle = title ? title : process.env.WEBSITE_TITLE;
-  let backToMarkup;
+  let navMarkup, footerMarkup;
 
   if (title) {
-    backToMarkup = backTo.replace(
-      /\{backLink\}/g,
-      '<a href="/">Back to ' + process.env.WEBSITE_TITLE + '</a>'
-    );
+    if (comment1 || comment2) {
+      navMarkup = nav.replace(
+        /\{navLink\}/g,
+        '<a href="#footer" class="icon solid fa-info-circle"></a>'
+      );
+    }
+    else {
+      navMarkup = nav.replace(
+        /\{navLink\}/g,
+        '<a href="/">Back to ' + process.env.WEBSITE_TITLE + '</a>'
+      );
+    }
   }
   else if (process.env.HOME_PAGE_CREDITS_OVERRIDE) {
-    backToMarkup = backTo.replace(
-      /\{backLink\}/g,
+    navMarkup = nav.replace(
+      /\{navLink\}/g,
       process.env.HOME_PAGE_CREDITS_OVERRIDE
     );
   }
   else if (!process.env.HIDE_HOME_PAGE_CREDITS) {
-    backToMarkup = backTo.replace(
-      /\{backLink\}/g,
+    navMarkup = nav.replace(
+      /\{navLink\}/g,
       '<a href="https://html5up.net">Design: HTML5 UP</a>'
     );
   }
   else {
-    backToMarkup = '';
+    navMarkup = '';
+  }
+
+  if (comment1 || comment2) {
+    let footerContent = '';
+
+    if (comment1) {
+      footerContent += '<p>' + comment1 + '</p>\n';
+    }
+    if (comment2) {
+      footerContent += '<p>' + comment2 + '</p>\n';
+    }
+
+    footerContent += (
+      '<p><a href="/">Back to ' + process.env.WEBSITE_TITLE + '</a></p>\n'
+    );
+
+    footerMarkup = footer.replace(/\{footerContent\}/g, footerContent);
+  }
+  else {
+    footerMarkup = '';
   }
 
   let body = data
     .toString()
     .replace(/\{title\}/g, pageTitle)
     .replace(/\{pictures\}/g, picturesHTML)
-    .replace(/\{backTo\}/g, backToMarkup);
+    .replace(/\{nav\}/g, navMarkup)
+    .replace(/\{footer\}/g, footerMarkup);
 
   // Test if "googleanalytics" is set or not
   if (!miscUtils.isEmpty(process.env.GOOGLEANALYTICS)) {
@@ -114,7 +153,7 @@ exports.uploadHomePage = function(albums, pictures, metadata) {
     const ga = fs.readFileSync('shared/snippets/ga.html').toString();
 
     const albumMarkup = fs.readFileSync('homepage/snippets/album.html').toString();
-    const backTo = fs.readFileSync('homepage/snippets/backto.html').toString();
+    const nav = fs.readFileSync('homepage/snippets/nav.html').toString();
 
     async.map(files, function(f, cb) {
       if (!f.includes('snippets')) {
@@ -125,7 +164,17 @@ exports.uploadHomePage = function(albums, pictures, metadata) {
           body = getErrorPageBody(data, ga);
         } else if (path.basename(f) === 'index.html') {
           body = getHomePageBody(
-            data, albums, pictures, metadata, albumMarkup, ga, backTo, null
+            data,
+            albums,
+            pictures,
+            metadata,
+            albumMarkup,
+            ga,
+            nav,
+            null,
+            null,
+            null,
+            null
           );
         }
         else {

--- a/test/site-builder/albumPage.spec.js
+++ b/test/site-builder/albumPage.spec.js
@@ -30,8 +30,8 @@ describe('albumPage', function() {
             '  </head>\n' +
             '  <body>\n' +
             '    <h1>{title}</h1>\n' +
-            '    <p>{comment1}</p>\n' +
-            '    <p>{comment2}</p>\n' +
+            '{comment1}\n' +
+            '{comment2}\n' +
             '{pictures}\n' +
             '  </body>\n' +
             '</html>\n'
@@ -119,8 +119,8 @@ describe('albumPage', function() {
         '\t</head>\n' +
         '\t<body>\n' +
         '\t\t<h1>Summer in Sicily</h1>\n' +
-        '\t\t<p>With my cat</p>\n' +
-        '\t\t<p>And my llama</p>\n' +
+        '<p>With my cat</p>\n' +
+        '<p>And my llama</p>\n' +
         picture1Markup +
         picture2Markup + "\n" +
         '\t</body>\n' +
@@ -189,9 +189,7 @@ describe('albumPage', function() {
         '    <title>null</title>\n' +
         '  </head>\n' +
         '  <body>\n' +
-        '    <h1>null</h1>\n' +
-        '    <p></p>\n' +
-        '    <p></p>\n' +
+        '    <h1>null</h1>\n\n\n' +
         picture1Markup +
         picture2Markup + "\n" +
         '  </body>\n' +

--- a/test/site-builder/index.spec.js
+++ b/test/site-builder/index.spec.js
@@ -93,8 +93,8 @@ describe('index', function() {
             '</head>\n' +
             '<body>\n' +
             '<h1>{title}</h1>\n' +
-            '<p>{comment1}</p>\n' +
-            '<p>{comment2}</p>\n' +
+            '{comment1}\n' +
+            '{comment2}\n' +
             '{pictures}\n' +
             '</body>\n' +
             '</html>\n'
@@ -278,9 +278,7 @@ describe('index', function() {
         '<title>carrotsincuba</title>\n' +
         '</head>\n' +
         '<body>\n' +
-        '<h1>carrotsincuba</h1>\n' +
-        '<p></p>\n' +
-        '<p></p>\n' +
+        '<h1>carrotsincuba</h1>\n\n\n' +
         picture3Markup +
         picture4Markup +
         picture5Markup + "\n" +

--- a/test/site-builder/uploadContents.spec.js
+++ b/test/site-builder/uploadContents.spec.js
@@ -28,8 +28,16 @@ describe('uploadContents', function() {
             else if (key === 'pics/original/whitewinter/metadata.yml') {
               cb(null, {Body: (
                 'title: White Winter\n' +
+                'comment1: Oh it was so white\n' +
+                'comment2: So very whitey white\n' +
                 'cover_image: soggysundays/rainy.jpg\n'
               )});
+            }
+            else if (key === 'pics/original/artyautumn/metadata.yml') {
+              cb(null, {Body: 'comment2: All the leaves are brown\n'});
+            }
+            else if (key === 'pics/original/moo/metadata.yml') {
+              cb(null, {Body: 'comment1: Said the cow\n'});
             }
             else {
               cb(true, null);
@@ -49,8 +57,9 @@ describe('uploadContents', function() {
             '</head>\n' +
             '<body>\n' +
             '<h1>{title}</h1>\n' +
-            '{backTo}\n' +
+            '{nav}\n' +
             '{pictures}\n' +
+            '{footer}\n' +
             '</body>\n' +
             '</html>\n'
           );
@@ -78,8 +87,8 @@ describe('uploadContents', function() {
             '</head>\n' +
             '<body>\n' +
             '<h1>{title}</h1>\n' +
-            '<p>{comment1}</p>\n' +
-            '<p>{comment2}</p>\n' +
+            '{comment1}\n' +
+            '{comment2}\n' +
             '{pictures}\n' +
             '</body>\n' +
             '</html>\n'
@@ -105,8 +114,15 @@ describe('uploadContents', function() {
             '    </article>\n'
           );
         }
-        else if (f.includes('backto.html')) {
-          return '{backLink}\n';
+        else if (f.includes('nav.html')) {
+          return '{navLink}\n';
+        }
+        else if (f.includes('footer.html')) {
+          return (
+            '<footer>\n' +
+            '{footerContent}\n' +
+            '</footer>\n'
+          );
         }
         else if (f.includes('main.css')) {
           return 'cssgoeshere';
@@ -192,6 +208,8 @@ describe('uploadContents', function() {
         {Key: 'pics/original/artyautumn/terrifictrees/oak.jpg'},
         {Key: 'pics/original/artyautumn/terrifictrees/birch.jpg'},
         {Key: 'pics/original/artyautumn/boisterousbirds/galah.jpg'},
+        {Key: 'pics/original/moo/metadata.yml'},
+        {Key: 'pics/original/moo/boo/zoo.jpg'}
       ];
 
       uploadContents.uploadAllContents(allContents);
@@ -212,6 +230,14 @@ describe('uploadContents', function() {
         "\t\t\t<h2>artyautumn</h2>\n" +
         "\t\t</article>\n"
       );
+      const coll3Markup = (
+        "\t\t<article>\n" +
+        "\t\t\t<a href=\"/moo/index.html\">\n" +
+        "\t\t\t\t<img src=\"/pics/resized/1200x750/moo/boo/zoo.jpg\" />\n" +
+        "\t\t\t</a>\n" +
+        "\t\t\t<h2>moo</h2>\n" +
+        "\t\t</article>\n"
+      );
 
       const expectedIndexBody = (
         '<html>\n' +
@@ -222,7 +248,8 @@ describe('uploadContents', function() {
         "<h1>Johnny's Awesome Photos</h1>\n" +
         '<a href="https://html5up.net">Design: HTML5 UP</a>\n\n' +
         coll1Markup +
-        coll2Markup + "\n" +
+        coll2Markup +
+        coll3Markup + "\n\n" +
         '</body>\n' +
         '</html>\n'
       );
@@ -263,9 +290,13 @@ describe('uploadContents', function() {
         '</head>\n' +
         '<body>\n' +
         "<h1>artyautumn</h1>\n" +
-        '<a href="/">Back to Johnny\'s Awesome Photos</a>\n\n' +
+        '<a href="#footer" class="icon solid fa-info-circle"></a>\n\n' +
         coll1album1Markup +
         coll1album2Markup + "\n" +
+        "<footer>\n" +
+        "<p>All the leaves are brown</p>\n" +
+        '<p><a href="/">Back to Johnny\'s Awesome Photos</a></p>\n\n' +
+        "</footer>\n\n" +
         '</body>\n' +
         '</html>\n'
       );
@@ -285,9 +316,7 @@ describe('uploadContents', function() {
         '<title>boisterousbirds</title>\n' +
         '</head>\n' +
         '<body>\n' +
-        '<h1>boisterousbirds</h1>\n' +
-        '<p></p>\n' +
-        '<p></p>\n' +
+        '<h1>boisterousbirds</h1>\n\n\n' +
         picture1Markup + "\n" +
         '</body>\n' +
         '</html>\n'
@@ -316,9 +345,7 @@ describe('uploadContents', function() {
         '<title>terrifictrees</title>\n' +
         '</head>\n' +
         '<body>\n' +
-        '<h1>terrifictrees</h1>\n' +
-        '<p></p>\n' +
-        '<p></p>\n' +
+        '<h1>terrifictrees</h1>\n\n\n' +
         picture2Markup +
         picture3Markup + "\n" +
         '</body>\n' +
@@ -349,9 +376,14 @@ describe('uploadContents', function() {
         '</head>\n' +
         '<body>\n' +
         "<h1>White Winter</h1>\n" +
-        '<a href="/">Back to Johnny\'s Awesome Photos</a>\n\n' +
+        '<a href="#footer" class="icon solid fa-info-circle"></a>\n\n' +
         coll2album1Markup +
         coll2album2Markup + "\n" +
+        "<footer>\n" +
+        "<p>Oh it was so white</p>\n" +
+        "<p>So very whitey white</p>\n" +
+        '<p><a href="/">Back to Johnny\'s Awesome Photos</a></p>\n\n' +
+        "</footer>\n\n" +
         '</body>\n' +
         '</html>\n'
       );
@@ -387,9 +419,7 @@ describe('uploadContents', function() {
         '<title>Soggy Sundays</title>\n' +
         '</head>\n' +
         '<body>\n' +
-        '<h1>Soggy Sundays</h1>\n' +
-        '<p></p>\n' +
-        '<p></p>\n' +
+        '<h1>Soggy Sundays</h1>\n\n\n' +
         picture4Markup +
         picture5Markup +
         picture6Markup + "\n" +
@@ -420,16 +450,61 @@ describe('uploadContents', function() {
         '<title>muggymondays</title>\n' +
         '</head>\n' +
         '<body>\n' +
-        '<h1>muggymondays</h1>\n' +
-        '<p></p>\n' +
-        '<p></p>\n' +
+        '<h1>muggymondays</h1>\n\n\n' +
         picture7Markup +
         picture8Markup + "\n" +
         '</body>\n' +
         '</html>\n'
       );
 
-      expect(putObjectFake).to.have.callCount(11);
+      const coll3album1Markup = (
+        "\t\t<article>\n" +
+        "\t\t\t<a href=\"/moo/boo/index.html\">\n" +
+        "\t\t\t\t<img src=\"/pics/resized/1200x750/moo/boo/zoo.jpg\" />\n" +
+        "\t\t\t</a>\n" +
+        "\t\t\t<h2>boo</h2>\n" +
+        "\t\t</article>\n"
+      );
+
+      const expectedColl3Body = (
+        '<html>\n' +
+        '<head>\n\n' +
+        "<title>moo</title>\n" +
+        '</head>\n' +
+        '<body>\n' +
+        "<h1>moo</h1>\n" +
+        '<a href="#footer" class="icon solid fa-info-circle"></a>\n\n' +
+        coll3album1Markup + "\n" +
+        "<footer>\n" +
+        "<p>Said the cow</p>\n" +
+        '<p><a href="/">Back to Johnny\'s Awesome Photos</a></p>\n\n' +
+        "</footer>\n\n" +
+        '</body>\n' +
+        '</html>\n'
+      );
+
+      const picture9Markup = (
+        "\t\t<article>\n" +
+        "\t\t\t<a href=\"/pics/resized/1200x750/moo/boo/zoo.jpg\">\n" +
+        "\t\t\t\t<img src=\"/pics/resized/360x225/moo/boo/zoo.jpg\" />\n" +
+        "\t\t\t</a>\n" +
+        "\t\t\t<p><a href=\"/pics/original/moo/boo/zoo.jpg\">DL</a></p>\n" +
+        "\t\t</article>\n"
+      );
+
+      const expectedColl3Album1Body = (
+        '<html>\n' +
+        '<head>\n\n' +
+        '<title>boo</title>\n' +
+        '</head>\n' +
+        '<body>\n' +
+        '<h1>boo</h1>\n\n\n' +
+        picture9Markup + "\n" +
+        '</body>\n' +
+        '</html>\n'
+      );
+
+      expect(putObjectFake).to.have.callCount(13);
 
       expect(putObjectFake).to.have.been.calledWith({
         Body: expectedIndexBody,
@@ -508,12 +583,34 @@ describe('uploadContents', function() {
         Key: 'whitewinter/muggymondays/index.html'
       });
 
-      expect(console.log).to.have.callCount(12);
+      expect(putObjectFake).to.have.been.calledWith({
+        Body: expectedColl3Body,
+        Bucket: 'johnnyphotos',
+        ContentType: 'text/html',
+        Key: 'moo/index.html'
+      });
+
+      expect(putObjectFake).to.have.been.calledWith({
+        Body: expectedColl3Album1Body,
+        Bucket: 'johnnyphotos',
+        ContentType: 'text/html',
+        Key: 'moo/boo/index.html'
+      });
+
+      expect(console.log).to.have.callCount(16);
 
       expect(console.log)
-        .to.have.been.calledWith('First collection: artyautumn');
+        .to.have.been.calledWith('First collection: moo');
       expect(console.log)
         .to.have.been.calledWith('Last collection: whitewinter');
+      expect(console.log)
+        .to.have.been.calledWith('First album in moo: boo');
+      expect(console.log)
+        .to.have.been.calledWith('Last album in moo: boo');
+      expect(console.log)
+        .to.have.been.calledWith('Writing collection moo');
+      expect(console.log)
+        .to.have.been.calledWith('Writing album boo');
       expect(console.log)
         .to.have.been.calledWith('First album in artyautumn: boisterousbirds');
       expect(console.log)
@@ -598,7 +695,7 @@ describe('uploadContents', function() {
         "<h1>Johnny's Awesome Photos</h1>\n" +
         '<a href="https://html5up.net">Design: HTML5 UP</a>\n\n' +
         coll1Markup +
-        coll2Markup + "\n" +
+        coll2Markup + "\n\n" +
         '</body>\n' +
         '</html>\n'
       );
@@ -639,9 +736,13 @@ describe('uploadContents', function() {
         '</head>\n' +
         '<body>\n' +
         "<h1>artyautumn</h1>\n" +
-        '<a href="/">Back to Johnny\'s Awesome Photos</a>\n\n' +
+        '<a href="#footer" class="icon solid fa-info-circle"></a>\n\n' +
         coll1album1Markup +
         coll1album2Markup + "\n" +
+        "<footer>\n" +
+        "<p>All the leaves are brown</p>\n" +
+        '<p><a href="/">Back to Johnny\'s Awesome Photos</a></p>\n\n' +
+        "</footer>\n\n" +
         '</body>\n' +
         '</html>\n'
       );
@@ -661,9 +762,7 @@ describe('uploadContents', function() {
         '<title>boisterousbirds</title>\n' +
         '</head>\n' +
         '<body>\n' +
-        '<h1>boisterousbirds</h1>\n' +
-        '<p></p>\n' +
-        '<p></p>\n' +
+        '<h1>boisterousbirds</h1>\n\n\n' +
         picture1Markup + "\n" +
         '</body>\n' +
         '</html>\n'
@@ -692,9 +791,7 @@ describe('uploadContents', function() {
         '<title>terrifictrees</title>\n' +
         '</head>\n' +
         '<body>\n' +
-        '<h1>terrifictrees</h1>\n' +
-        '<p></p>\n' +
-        '<p></p>\n' +
+        '<h1>terrifictrees</h1>\n\n\n' +
         picture2Markup +
         picture3Markup + "\n" +
         '</body>\n' +
@@ -725,9 +822,14 @@ describe('uploadContents', function() {
         '</head>\n' +
         '<body>\n' +
         "<h1>White Winter</h1>\n" +
-        '<a href="/">Back to Johnny\'s Awesome Photos</a>\n\n' +
+        '<a href="#footer" class="icon solid fa-info-circle"></a>\n\n' +
         coll2album1Markup +
         coll2album2Markup + "\n" +
+        "<footer>\n" +
+        "<p>Oh it was so white</p>\n" +
+        "<p>So very whitey white</p>\n" +
+        '<p><a href="/">Back to Johnny\'s Awesome Photos</a></p>\n\n' +
+        "</footer>\n\n" +
         '</body>\n' +
         '</html>\n'
       );
@@ -763,9 +865,7 @@ describe('uploadContents', function() {
         '<title>Soggy Sundays</title>\n' +
         '</head>\n' +
         '<body>\n' +
-        '<h1>Soggy Sundays</h1>\n' +
-        '<p></p>\n' +
-        '<p></p>\n' +
+        '<h1>Soggy Sundays</h1>\n\n\n' +
         picture4Markup +
         picture5Markup +
         picture6Markup + "\n" +
@@ -796,9 +896,7 @@ describe('uploadContents', function() {
         '<title>muggymondays</title>\n' +
         '</head>\n' +
         '<body>\n' +
-        '<h1>muggymondays</h1>\n' +
-        '<p></p>\n' +
-        '<p></p>\n' +
+        '<h1>muggymondays</h1>\n\n\n' +
         picture7Markup +
         picture8Markup + "\n" +
         '</body>\n' +
@@ -977,7 +1075,7 @@ describe('uploadContents', function() {
         "<h1>Johnny's Awesome Photos</h1>\n" +
         '<a href="https://html5up.net">Design: HTML5 UP</a>\n\n' +
         coll1Markup +
-        coll2Markup + "\n" +
+        coll2Markup + "\n\n" +
         '</body>\n' +
         '</html>\n'
       );
@@ -1018,9 +1116,13 @@ describe('uploadContents', function() {
         '</head>\n' +
         '<body>\n' +
         "<h1>artyautumn</h1>\n" +
-        '<a href="/">Back to Johnny\'s Awesome Photos</a>\n\n' +
+        '<a href="#footer" class="icon solid fa-info-circle"></a>\n\n' +
         coll1album1Markup +
         coll1album2Markup + "\n" +
+        "<footer>\n" +
+        "<p>All the leaves are brown</p>\n" +
+        '<p><a href="/">Back to Johnny\'s Awesome Photos</a></p>\n\n' +
+        "</footer>\n\n" +
         '</body>\n' +
         '</html>\n'
       );
@@ -1040,9 +1142,7 @@ describe('uploadContents', function() {
         '<title>boisterousbirds</title>\n' +
         '</head>\n' +
         '<body>\n' +
-        '<h1>boisterousbirds</h1>\n' +
-        '<p></p>\n' +
-        '<p></p>\n' +
+        '<h1>boisterousbirds</h1>\n\n\n' +
         picture1Markup + "\n" +
         '</body>\n' +
         '</html>\n'
@@ -1071,9 +1171,7 @@ describe('uploadContents', function() {
         '<title>terrifictrees</title>\n' +
         '</head>\n' +
         '<body>\n' +
-        '<h1>terrifictrees</h1>\n' +
-        '<p></p>\n' +
-        '<p></p>\n' +
+        '<h1>terrifictrees</h1>\n\n\n' +
         picture2Markup +
         picture3Markup + "\n" +
         '</body>\n' +
@@ -1104,9 +1202,14 @@ describe('uploadContents', function() {
         '</head>\n' +
         '<body>\n' +
         "<h1>White Winter</h1>\n" +
-        '<a href="/">Back to Johnny\'s Awesome Photos</a>\n\n' +
+        '<a href="#footer" class="icon solid fa-info-circle"></a>\n\n' +
         coll2album1Markup +
         coll2album2Markup + "\n" +
+        "<footer>\n" +
+        "<p>Oh it was so white</p>\n" +
+        "<p>So very whitey white</p>\n" +
+        '<p><a href="/">Back to Johnny\'s Awesome Photos</a></p>\n\n' +
+        "</footer>\n\n" +
         '</body>\n' +
         '</html>\n'
       );
@@ -1142,9 +1245,7 @@ describe('uploadContents', function() {
         '<title>Soggy Sundays</title>\n' +
         '</head>\n' +
         '<body>\n' +
-        '<h1>Soggy Sundays</h1>\n' +
-        '<p></p>\n' +
-        '<p></p>\n' +
+        '<h1>Soggy Sundays</h1>\n\n\n' +
         picture4Markup +
         picture5Markup +
         picture6Markup + "\n" +
@@ -1175,9 +1276,7 @@ describe('uploadContents', function() {
         '<title>muggymondays</title>\n' +
         '</head>\n' +
         '<body>\n' +
-        '<h1>muggymondays</h1>\n' +
-        '<p></p>\n' +
-        '<p></p>\n' +
+        '<h1>muggymondays</h1>\n\n\n' +
         picture7Markup +
         picture8Markup + "\n" +
         '</body>\n' +


### PR DESCRIPTION
Support reading `comment1` and `comment2` values from a collection's `metadata.yml` , same as for an album, and displaying them on a collection's page.

I've put the collection description in the `<footer>` , and (if the collection has a description) changed the "back" link to a button that shows the footer panel (and in that case, the "back" link shows in the panel, under the description). This is the same as what the official example for "multiverse" does on the html5up site.