### PR TITLE
Authentication from subfolder

### DIFF
--- a/site-builder/homepage/error.html
+++ b/site-builder/homepage/error.html
@@ -211,13 +211,14 @@
         dataType: "json",
         success: function(data) {
           var cookies = $.map(data, function(c) { return c.split(';')[0]; });
+          var cookies = $.map(data, function(c) { return c.split(';')[0] + '; ' + c.split(';')[1] + '; ' + c.split(';')[2]; });
           for (var i = cookies.length - 1; i >= 0; i--) {
             document.cookie = cookies[i];
           }
           $this.addClass('ok');
           $state.html('Loading Site...');
           setTimeout(function() {
-            window.location.replace("https://{website}");
+            window.location.reload();
           }, 1000);
         },
         error: function(XMLHttpRequest, textStatus, errorThrown) {

--- a/site-builder/homepage/error.html
+++ b/site-builder/homepage/error.html
@@ -210,7 +210,6 @@
         contentType: "application/json",
         dataType: "json",
         success: function(data) {
-          var cookies = $.map(data, function(c) { return c.split(';')[0]; });
           var cookies = $.map(data, function(c) { return c.split(';')[0] + '; ' + c.split(';')[1] + '; ' + c.split(';')[2]; });
           for (var i = cookies.length - 1; i >= 0; i--) {
             document.cookie = cookies[i];


### PR DESCRIPTION
The use case is that a user tries to reach a particular album or photo within the gallery, but after login finds themself at the root of the gallery. 

Changed error.html page so that if authentication attempt happens from a subfolder, after authentication the actual url requested is delivered, yet the user still has access to the whole gallery. The cookies come back with attributes: "Domain" and "Path", which we want, but also "Secure" and HttpOnly", which for some reason I haven't yet understood means that Chrome won't apply the cookies. This code just keeps the Domain and path attributes; then it reloads the page rather than redirecting to the source of the gallery.