### PR TITLE
Use the first image in the album page as the homepage cover photo

### DIFF
--- a/site-builder/lib/album.js
+++ b/site-builder/lib/album.js
@@ -81,7 +81,23 @@ exports.getAlbumMarkup = function(albumName, pictures, metadata, albumMarkup) {
   let albumTitle = (albumName && albumName.includes('/')) ?
     pathUtils.secondLevelFolderName(albumName) :
     albumName;
-  let albumPicture = pictures[0];
+  const picturesSorted = pictures.slice();
+
+  if (process.env.PICTURE_SORT &&
+      process.env.PICTURE_SORT.toLowerCase() === 'asc') {
+    picturesSorted.sort();
+  }
+  else if (
+      process.env.PICTURE_SORT &&
+      process.env.PICTURE_SORT.toLowerCase() === 'desc') {
+    picturesSorted.sort();
+    picturesSorted.reverse();
+  }
+  else {
+    picturesSorted.reverse();
+  }
+  
+  let albumPicture = picturesSorted[0];
 
   if (metadata) {
     if (metadata.title) {

--- a/site-builder/lib/album.js
+++ b/site-builder/lib/album.js
@@ -93,9 +93,6 @@ exports.getAlbumMarkup = function(albumName, pictures, metadata, albumMarkup) {
     picturesSorted.sort();
     picturesSorted.reverse();
   }
-  else {
-    picturesSorted.reverse();
-  }
   
   let albumPicture = picturesSorted[0];
 

--- a/test/site-builder/index.spec.js
+++ b/test/site-builder/index.spec.js
@@ -176,7 +176,7 @@ describe('index', function() {
       const album1Markup = (
         "\t\t<article>\n" +
         "\t\t\t<a href=\"/carrotsincuba/index.html\">\n" +
-        "\t\t\t\t<img src=\"/pics/resized/1200x750/carrotsincuba/havana.jpg\" />\n" +
+        "\t\t\t\t<img src=\"/pics/resized/1200x750/carrotsincuba/carrots.jpg\" />\n" +
         "\t\t\t</a>\n" +
         "\t\t\t<h2>carrotsincuba</h2>\n" +
         "\t\t</article>\n"
@@ -184,7 +184,7 @@ describe('index', function() {
       const album2Markup = (
         "\t\t<article>\n" +
         "\t\t\t<a href=\"/bananasinbahamas/index.html\">\n" +
-        "\t\t\t\t<img src=\"/pics/resized/1200x750/bananasinbahamas/bananas.jpg\" />\n" +
+        "\t\t\t\t<img src=\"/pics/resized/1200x750/bananasinbahamas/bahamas.jpg\" />\n" +
         "\t\t\t</a>\n" +
         "\t\t\t<h2>Bananas in Bahamas</h2>\n" +
         "\t\t</article>\n"


### PR DESCRIPTION
By consistently sorting the photos.

This has no effect if the cover photo is explicitly specified in the album metadata yaml.